### PR TITLE
feat(TAS-338): expression syntax validation for composition templates

### DIFF
--- a/crates/tasker-grammar/src/validation/tests.rs
+++ b/crates/tasker-grammar/src/validation/tests.rs
@@ -90,7 +90,9 @@ fn make_registry() -> HashMap<String, CapabilityDeclaration> {
                 "required": ["resource"],
                 "properties": {
                     "resource": { "type": "object" },
-                    "params": { "type": "string" },
+                    "params": {},
+                    "validate_success": { "type": "object" },
+                    "result_shape": { "type": "object" },
                     "constraints": { "type": "object" }
                 }
             }),
@@ -108,10 +110,12 @@ fn make_registry() -> HashMap<String, CapabilityDeclaration> {
             description: "Write state".to_owned(),
             config_schema: json!({
                 "type": "object",
-                "required": ["resource", "data"],
+                "required": ["resource"],
                 "properties": {
                     "resource": { "type": "object" },
-                    "data": { "type": "string" },
+                    "data": {},
+                    "validate_success": { "type": "object" },
+                    "result_shape": { "type": "object" },
                     "constraints": { "type": "object" }
                 }
             }),
@@ -131,11 +135,14 @@ fn make_registry() -> HashMap<String, CapabilityDeclaration> {
             description: "Fire domain events".to_owned(),
             config_schema: json!({
                 "type": "object",
-                "required": ["event_name", "payload"],
+                "required": ["event_name"],
                 "properties": {
                     "event_name": { "type": "string" },
-                    "payload": { "type": "string" },
-                    "condition": { "type": "string" }
+                    "payload": {},
+                    "condition": {},
+                    "validate_success": { "type": "object" },
+                    "result_shape": { "type": "object" },
+                    "metadata": { "type": "object" }
                 }
             }),
             mutation_profile: MutationProfile::Mutating {
@@ -509,7 +516,7 @@ fn persist_data_expression_validated() {
             capability: "persist".to_owned(),
             config: json!({
                 "resource": { "type": "database" },
-                "data": "broken expression {{{ syntax"
+                "data": { "expression": "broken expression {{{ syntax" }
             }),
             checkpoint: true,
         }],
@@ -535,7 +542,7 @@ fn emit_payload_expression_validated() {
             capability: "emit".to_owned(),
             config: json!({
                 "event_name": "test.event",
-                "payload": "broken {{{ syntax"
+                "payload": { "expression": "broken {{{ syntax" }
             }),
             checkpoint: true,
         }],
@@ -561,8 +568,8 @@ fn emit_condition_expression_validated() {
             capability: "emit".to_owned(),
             config: json!({
                 "event_name": "test.event",
-                "payload": ".prev",
-                "condition": "broken {{{ syntax"
+                "payload": { "expression": ".prev" },
+                "condition": { "expression": "broken {{{ syntax" }
             }),
             checkpoint: true,
         }],

--- a/crates/tasker-grammar/src/validation/tests.rs
+++ b/crates/tasker-grammar/src/validation/tests.rs
@@ -579,6 +579,220 @@ fn emit_condition_expression_validated() {
     assert!(has_error(&result, "INVALID_EXPRESSION"));
 }
 
+#[test]
+fn persist_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "data": { "expression": ".prev" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.validate_success.expression")
+    );
+}
+
+#[test]
+fn persist_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "data": { "expression": ".prev" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.result_shape.expression")
+    );
+}
+
+#[test]
+fn acquire_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "acquire".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.validate_success.expression")
+    );
+}
+
+#[test]
+fn acquire_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "acquire".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.result_shape.expression")
+    );
+}
+
+#[test]
+fn emit_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.validate_success.expression")
+    );
+}
+
+#[test]
+fn emit_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.result_shape.expression")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Checkpoint coverage
 // ---------------------------------------------------------------------------

--- a/crates/tasker-grammar/src/validation/tests.rs
+++ b/crates/tasker-grammar/src/validation/tests.rs
@@ -524,6 +524,15 @@ fn persist_data_expression_validated() {
 
     let result = validator.validate(&spec);
     assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.data.expression")
+    );
 }
 
 #[test]
@@ -550,6 +559,15 @@ fn emit_payload_expression_validated() {
 
     let result = validator.validate(&spec);
     assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.payload.expression")
+    );
 }
 
 #[test]
@@ -577,6 +595,15 @@ fn emit_condition_expression_validated() {
 
     let result = validator.validate(&spec);
     assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.condition.expression")
+    );
 }
 
 #[test]

--- a/crates/tasker-grammar/src/validation/tests.rs
+++ b/crates/tasker-grammar/src/validation/tests.rs
@@ -793,6 +793,137 @@ fn emit_result_shape_expression_validated() {
     );
 }
 
+#[test]
+fn emit_metadata_correlation_id_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "metadata": {
+                    "correlation_id": { "expression": "broken {{{ syntax" }
+                }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.metadata.correlation_id.expression")
+    );
+}
+
+#[test]
+fn emit_metadata_idempotency_key_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "metadata": {
+                    "idempotency_key": { "expression": "broken {{{ syntax" }
+                }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result
+        .findings
+        .iter()
+        .find(|f| f.code == "INVALID_EXPRESSION")
+        .unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.metadata.idempotency_key.expression")
+    );
+}
+
+#[test]
+fn valid_nested_expressions_pass() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "acquire".to_owned(),
+                config: json!({
+                    "resource": { "type": "database" },
+                    "params": { "expression": "{customer_id: .context.id}" },
+                    "validate_success": { "expression": ".total_count > 0" },
+                    "result_shape": { "expression": ".data[0]" }
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "persist".to_owned(),
+                config: json!({
+                    "resource": { "type": "database" },
+                    "data": { "expression": "{id: .prev.order_id}" },
+                    "validate_success": { "expression": ".affected_rows > 0" },
+                    "result_shape": { "expression": "{persisted_id: .id}" }
+                }),
+                checkpoint: true,
+            },
+            CapabilityInvocation {
+                capability: "emit".to_owned(),
+                config: json!({
+                    "event_name": "order.created",
+                    "payload": { "expression": ".prev" },
+                    "condition": { "expression": ".prev.persisted_id != null" },
+                    "validate_success": { "expression": ".delivered" },
+                    "result_shape": { "expression": "{event_id: .message_id}" },
+                    "metadata": {
+                        "correlation_id": { "expression": ".context.request_id" },
+                        "idempotency_key": { "expression": ".prev.persisted_id | tostring" }
+                    }
+                }),
+                checkpoint: true,
+            },
+        ],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(!has_finding(&result, "INVALID_EXPRESSION"));
+}
+
 // ---------------------------------------------------------------------------
 // Checkpoint coverage
 // ---------------------------------------------------------------------------

--- a/crates/tasker-grammar/src/validation/validator.rs
+++ b/crates/tasker-grammar/src/validation/validator.rs
@@ -165,6 +165,24 @@ impl fmt::Debug for CompositionValidator<'_> {
     }
 }
 
+/// Extract a jaq expression string from a config field value.
+///
+/// Handles two shapes:
+/// - Flat string: `"filter": ".context.name"` → `Some(".context.name")`
+/// - ExpressionField object: `"data": {"expression": ".prev"}` → `Some(".prev")`
+/// - Anything else: `None`
+fn extract_expression(value: &Value) -> Option<&str> {
+    // Flat string (used by transform filter, assert filter)
+    if let Some(s) = value.as_str() {
+        return Some(s);
+    }
+    // ExpressionField object (used by persist/acquire/emit fields)
+    value
+        .as_object()
+        .and_then(|obj| obj.get("expression"))
+        .and_then(|v| v.as_str())
+}
+
 impl<'a> CompositionValidator<'a> {
     /// Create a new validator with the given capability registry and expression engine.
     pub fn new(
@@ -410,17 +428,24 @@ impl<'a> CompositionValidator<'a> {
             };
 
             // Determine which config fields contain jaq expressions based on category
-            let expression_fields = match decl.grammar_category {
-                GrammarCategoryKind::Transform => vec!["filter"],
-                GrammarCategoryKind::Assert => vec!["filter"],
-                GrammarCategoryKind::Persist => vec!["data"],
-                GrammarCategoryKind::Acquire => vec!["params"],
-                GrammarCategoryKind::Emit => vec!["payload", "condition"],
-                GrammarCategoryKind::Validate => vec![], // No jaq expressions
+            let expression_fields: &[&str] = match decl.grammar_category {
+                GrammarCategoryKind::Transform => &["filter"],
+                GrammarCategoryKind::Assert => &["filter"],
+                GrammarCategoryKind::Persist => &["data", "validate_success", "result_shape"],
+                GrammarCategoryKind::Acquire => &["params", "validate_success", "result_shape"],
+                GrammarCategoryKind::Emit => {
+                    &["payload", "condition", "validate_success", "result_shape"]
+                }
+                GrammarCategoryKind::Validate => &[],
             };
 
             for field in expression_fields {
-                if let Some(Value::String(expr)) = invocation.config.get(field) {
+                if let Some(value) = invocation.config.get(*field) {
+                    let (expr, field_path) = match extract_expression(value) {
+                        Some(e) if value.is_string() => (e, format!("config.{field}")),
+                        Some(e) => (e, format!("config.{field}.expression")),
+                        None => continue,
+                    };
                     if let Err(e) = self.expression_engine.validate_syntax(expr) {
                         findings.push(ValidationFinding {
                             severity: Severity::Error,
@@ -428,10 +453,37 @@ impl<'a> CompositionValidator<'a> {
                             invocation_index: Some(idx),
                             message: format!(
                                 "invocation {} ({}) has invalid jaq expression in '{}': {e}",
-                                idx, invocation.capability, field
+                                idx, invocation.capability, field_path
                             ),
-                            field_path: Some(format!("config.{field}")),
+                            field_path: Some(field_path),
                         });
+                    }
+                }
+            }
+
+            // Emit metadata expressions (nested one level deeper).
+            // Metadata fields are always ExpressionField objects in practice.
+            if matches!(decl.grammar_category, GrammarCategoryKind::Emit) {
+                if let Some(metadata) = invocation.config.get("metadata").and_then(Value::as_object)
+                {
+                    for meta_field in &["correlation_id", "idempotency_key"] {
+                        if let Some(value) = metadata.get(*meta_field) {
+                            if let Some(expr) = extract_expression(value) {
+                                let field_path = format!("config.metadata.{meta_field}.expression");
+                                if let Err(e) = self.expression_engine.validate_syntax(expr) {
+                                    findings.push(ValidationFinding {
+                                        severity: Severity::Error,
+                                        code: "INVALID_EXPRESSION".to_owned(),
+                                        invocation_index: Some(idx),
+                                        message: format!(
+                                            "invocation {} ({}) has invalid jaq expression in '{}': {e}",
+                                            idx, invocation.capability, field_path
+                                        ),
+                                        field_path: Some(field_path),
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/docs/superpowers/plans/2026-03-20-tas-338-expression-syntax-validation.md
+++ b/docs/superpowers/plans/2026-03-20-tas-338-expression-syntax-validation.md
@@ -1,0 +1,658 @@
+# TAS-338: Expression Syntax Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `check_expression_syntax` to validate jaq expressions in both flat string and `ExpressionField` object shapes, covering all expression-bearing config fields including `validate_success`, `result_shape`, and emit metadata.
+
+**Architecture:** A free function `extract_expression` handles both `"expr"` (flat string) and `{"expression": "expr"}` (ExpressionField object) shapes. The existing `check_expression_syntax` method gets updated field lists and uses the helper for extraction. Emit metadata gets special handling for its nested structure. Test registry schemas are updated to accept object-type expression fields.
+
+**Tech Stack:** Rust, serde_json, jaq-core (via ExpressionEngine)
+
+**Spec:** `docs/superpowers/specs/2026-03-20-tas-338-expression-syntax-validation-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `crates/tasker-grammar/src/validation/validator.rs` | Expression extraction helper (free function) + rewritten `check_expression_syntax` |
+| `crates/tasker-grammar/src/validation/tests.rs` | Updated test registry schemas + updated existing tests + new tests for all expression fields |
+
+No new files. No SDK changes. All work is in the grammar crate's validation module.
+
+---
+
+## Task 1: Add expression extraction helper and extend `check_expression_syntax`
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/validation/validator.rs`
+
+- [ ] **Step 1: Add the `extract_expression` free function**
+
+Add this function **before** the `impl<'a> CompositionValidator<'a>` block (before line 168 in `validator.rs`). It must be a free function, not a method, because it takes no `&self`:
+
+```rust
+/// Extract a jaq expression string from a config field value.
+///
+/// Handles two shapes:
+/// - Flat string: `"filter": ".context.name"` → `Some(".context.name")`
+/// - ExpressionField object: `"data": {"expression": ".prev"}` → `Some(".prev")`
+/// - Anything else: `None`
+fn extract_expression(value: &Value) -> Option<&str> {
+    // Flat string (used by transform filter, assert filter)
+    if let Some(s) = value.as_str() {
+        return Some(s);
+    }
+    // ExpressionField object (used by persist/acquire/emit fields)
+    value
+        .as_object()
+        .and_then(|obj| obj.get("expression"))
+        .and_then(|v| v.as_str())
+}
+```
+
+- [ ] **Step 2: Rewrite `check_expression_syntax` with extended field lists and extraction helper**
+
+Replace the existing `check_expression_syntax` method (lines 398-438) with:
+
+```rust
+/// Validate jaq expression syntax in configs.
+fn check_expression_syntax(
+    &self,
+    spec: &CompositionSpec,
+    resolved: &[Option<&CapabilityDeclaration>],
+    findings: &mut Vec<ValidationFinding>,
+) {
+    for (idx, (invocation, decl_opt)) in
+        spec.invocations.iter().zip(resolved.iter()).enumerate()
+    {
+        let Some(decl) = decl_opt else {
+            continue;
+        };
+
+        // Determine which config fields contain jaq expressions based on category
+        let expression_fields: &[&str] = match decl.grammar_category {
+            GrammarCategoryKind::Transform => &["filter"],
+            GrammarCategoryKind::Assert => &["filter"],
+            GrammarCategoryKind::Persist => &["data", "validate_success", "result_shape"],
+            GrammarCategoryKind::Acquire => &["params", "validate_success", "result_shape"],
+            GrammarCategoryKind::Emit => {
+                &["payload", "condition", "validate_success", "result_shape"]
+            }
+            GrammarCategoryKind::Validate => &[],
+        };
+
+        for field in expression_fields {
+            if let Some(value) = invocation.config.get(*field) {
+                let (expr, field_path) = match extract_expression(value) {
+                    Some(e) if value.is_string() => (e, format!("config.{field}")),
+                    Some(e) => (e, format!("config.{field}.expression")),
+                    None => continue,
+                };
+                if let Err(e) = self.expression_engine.validate_syntax(expr) {
+                    findings.push(ValidationFinding {
+                        severity: Severity::Error,
+                        code: "INVALID_EXPRESSION".to_owned(),
+                        invocation_index: Some(idx),
+                        message: format!(
+                            "invocation {} ({}) has invalid jaq expression in '{}': {e}",
+                            idx, invocation.capability, field_path
+                        ),
+                        field_path: Some(field_path),
+                    });
+                }
+            }
+        }
+
+        // Emit metadata expressions (nested one level deeper).
+        // Metadata fields are always ExpressionField objects in practice.
+        if matches!(decl.grammar_category, GrammarCategoryKind::Emit) {
+            if let Some(metadata) =
+                invocation.config.get("metadata").and_then(Value::as_object)
+            {
+                for meta_field in &["correlation_id", "idempotency_key"] {
+                    if let Some(value) = metadata.get(*meta_field) {
+                        if let Some(expr) = extract_expression(value) {
+                            let field_path =
+                                format!("config.metadata.{meta_field}.expression");
+                            if let Err(e) =
+                                self.expression_engine.validate_syntax(expr)
+                            {
+                                findings.push(ValidationFinding {
+                                    severity: Severity::Error,
+                                    code: "INVALID_EXPRESSION".to_owned(),
+                                    invocation_index: Some(idx),
+                                    message: format!(
+                                        "invocation {} ({}) has invalid jaq expression in '{}': {e}",
+                                        idx, invocation.capability, field_path
+                                    ),
+                                    field_path: Some(field_path),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check --package tasker-grammar --all-features`
+Expected: Compiles successfully
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `cargo test --package tasker-grammar --all-features -- validation::tests --nocapture`
+Expected: All existing tests pass (the extraction helper handles flat strings, so transform/assert tests continue to work; persist/emit tests still work because flat strings are still supported)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tasker-grammar/src/validation/validator.rs
+git commit -m "feat(TAS-338): add expression extraction helper and extend check_expression_syntax
+
+Support both flat string and ExpressionField object shapes. Add
+validate_success, result_shape fields for persist/acquire/emit.
+Add emit metadata expression validation."
+```
+
+---
+
+## Task 2: Update test registry schemas and existing tests to use ExpressionField object shape
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/validation/tests.rs`
+
+**Context:** The test registry's config schemas declare expression-bearing fields as `"type": "string"` (e.g., `"data": {"type": "string"}`). When we change test data to use `{"expression": "..."}` objects, the `check_config_schemas` validation pass fires `CONFIG_SCHEMA_VIOLATION` before expression syntax validation runs. We must update the registry schemas to accept both string and object types for expression-bearing fields.
+
+- [ ] **Step 1: Update `make_registry()` config schemas to accept ExpressionField objects**
+
+In `make_registry()` (starts at line 19), update the config schemas for persist, acquire, and emit to accept both string and object for expression-bearing fields:
+
+For **persist** (around line 109-116), change:
+```rust
+config_schema: json!({
+    "type": "object",
+    "required": ["resource"],
+    "properties": {
+        "resource": { "type": "object" },
+        "data": {},
+        "validate_success": { "type": "object" },
+        "result_shape": { "type": "object" },
+        "constraints": { "type": "object" }
+    }
+}),
+```
+
+For **acquire** (around line 88-96), change:
+```rust
+config_schema: json!({
+    "type": "object",
+    "required": ["resource"],
+    "properties": {
+        "resource": { "type": "object" },
+        "params": {},
+        "validate_success": { "type": "object" },
+        "result_shape": { "type": "object" },
+        "constraints": { "type": "object" }
+    }
+}),
+```
+
+For **emit** (around line 132-139), change:
+```rust
+config_schema: json!({
+    "type": "object",
+    "required": ["event_name"],
+    "properties": {
+        "event_name": { "type": "string" },
+        "payload": {},
+        "condition": {},
+        "validate_success": { "type": "object" },
+        "result_shape": { "type": "object" },
+        "metadata": { "type": "object" }
+    }
+}),
+```
+
+Note: Using `{}` (empty schema, accepts any type) for fields that can be either flat strings or ExpressionField objects. Also removed `"data"` and `"payload"` from `required` lists since the expression shape is an object not a string, and added the new fields (`validate_success`, `result_shape`, `metadata`) to properties.
+
+- [ ] **Step 2: Update `persist_data_expression_validated` test (around line 497)**
+
+Change the config from:
+```rust
+"data": "broken expression {{{ syntax"
+```
+to:
+```rust
+"data": { "expression": "broken expression {{{ syntax" }
+```
+
+- [ ] **Step 3: Update `emit_payload_expression_validated` test (around line 522)**
+
+Change the config from:
+```rust
+"payload": "broken {{{ syntax"
+```
+to:
+```rust
+"payload": { "expression": "broken {{{ syntax" }
+```
+
+- [ ] **Step 4: Update `emit_condition_expression_validated` test (around line 548)**
+
+Change the config from:
+```rust
+"payload": ".prev",
+"condition": "broken {{{ syntax"
+```
+to:
+```rust
+"payload": { "expression": ".prev" },
+"condition": { "expression": "broken {{{ syntax" }
+```
+
+- [ ] **Step 5: Run updated tests to verify they pass**
+
+Run: `cargo test --package tasker-grammar --all-features -- validation::tests --nocapture`
+Expected: All tests pass. The updated schemas accept object values and the extraction helper handles ExpressionField objects.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-grammar/src/validation/tests.rs
+git commit -m "test(TAS-338): update registry schemas and tests for ExpressionField shape
+
+Update test registry config schemas to accept ExpressionField objects
+alongside flat strings. Update persist_data, emit_payload, and
+emit_condition tests to use real {\"expression\": \"...\"} shape."
+```
+
+---
+
+## Task 3: Add tests for validate_success and result_shape expressions
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/validation/tests.rs` (append after the expression syntax tests section, around line 573)
+
+- [ ] **Step 1: Write the 6 new tests for validate_success and result_shape**
+
+Add after the existing `emit_condition_expression_validated` test:
+
+```rust
+#[test]
+fn persist_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "data": { "expression": ".prev" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.validate_success.expression"));
+}
+
+#[test]
+fn persist_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "data": { "expression": ".prev" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.result_shape.expression"));
+}
+
+#[test]
+fn acquire_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "acquire".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.validate_success.expression"));
+}
+
+#[test]
+fn acquire_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "acquire".to_owned(),
+            config: json!({
+                "resource": { "type": "database" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.result_shape.expression"));
+}
+
+#[test]
+fn emit_validate_success_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "validate_success": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.validate_success.expression"));
+}
+
+#[test]
+fn emit_result_shape_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "result_shape": { "expression": "broken {{{ syntax" }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(finding.field_path.as_deref(), Some("config.result_shape.expression"));
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `cargo test --package tasker-grammar --all-features -- validation::tests --nocapture`
+Expected: All tests pass including the 6 new ones
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/tasker-grammar/src/validation/tests.rs
+git commit -m "test(TAS-338): add validate_success and result_shape expression tests
+
+Cover all 6 combinations: persist/acquire/emit x validate_success/result_shape.
+Each test verifies INVALID_EXPRESSION error with correct field_path."
+```
+
+---
+
+## Task 4: Add tests for emit metadata expressions and valid-expressions-pass
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/validation/tests.rs` (append after Task 3 tests)
+
+- [ ] **Step 1: Write metadata and valid-expressions tests**
+
+Append:
+
+```rust
+#[test]
+fn emit_metadata_correlation_id_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "metadata": {
+                    "correlation_id": { "expression": "broken {{{ syntax" }
+                }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.metadata.correlation_id.expression")
+    );
+}
+
+#[test]
+fn emit_metadata_idempotency_key_expression_validated() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "emit".to_owned(),
+            config: json!({
+                "event_name": "test.event",
+                "payload": { "expression": ".prev" },
+                "metadata": {
+                    "idempotency_key": { "expression": "broken {{{ syntax" }
+                }
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(has_error(&result, "INVALID_EXPRESSION"));
+    let finding = result.findings.iter().find(|f| f.code == "INVALID_EXPRESSION").unwrap();
+    assert_eq!(
+        finding.field_path.as_deref(),
+        Some("config.metadata.idempotency_key.expression")
+    );
+}
+
+#[test]
+fn valid_nested_expressions_pass() {
+    let registry = make_registry();
+    let engine = make_engine();
+    let validator = make_validator(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "acquire".to_owned(),
+                config: json!({
+                    "resource": { "type": "database" },
+                    "params": { "expression": "{customer_id: .context.id}" },
+                    "validate_success": { "expression": ".total_count > 0" },
+                    "result_shape": { "expression": ".data[0]" }
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "persist".to_owned(),
+                config: json!({
+                    "resource": { "type": "database" },
+                    "data": { "expression": "{id: .prev.order_id}" },
+                    "validate_success": { "expression": ".affected_rows > 0" },
+                    "result_shape": { "expression": "{persisted_id: .id}" }
+                }),
+                checkpoint: true,
+            },
+            CapabilityInvocation {
+                capability: "emit".to_owned(),
+                config: json!({
+                    "event_name": "order.created",
+                    "payload": { "expression": ".prev" },
+                    "condition": { "expression": ".prev.persisted_id != null" },
+                    "validate_success": { "expression": ".delivered" },
+                    "result_shape": { "expression": "{event_id: .message_id}" },
+                    "metadata": {
+                        "correlation_id": { "expression": ".context.request_id" },
+                        "idempotency_key": { "expression": ".prev.persisted_id | tostring" }
+                    }
+                }),
+                checkpoint: true,
+            },
+        ],
+    };
+
+    let result = validator.validate(&spec);
+    assert!(!has_finding(&result, "INVALID_EXPRESSION"));
+}
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cargo test --package tasker-grammar --all-features -- validation::tests --nocapture`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/tasker-grammar/src/validation/tests.rs
+git commit -m "test(TAS-338): add emit metadata and valid-expressions-pass tests
+
+Cover metadata.correlation_id and metadata.idempotency_key expression
+validation. Add comprehensive valid-expressions test covering all three
+capabilities with all ExpressionField shapes."
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run full grammar test suite**
+
+Run: `cargo test --package tasker-grammar --all-features`
+Expected: All tests pass (448+ grammar tests)
+
+- [ ] **Step 2: Run workspace clippy**
+
+Run: `cargo clippy --all-targets --all-features --workspace`
+Expected: Zero warnings
+
+- [ ] **Step 3: Run workspace check**
+
+Run: `cargo check --all-features --workspace`
+Expected: Clean compilation
+
+- [ ] **Step 4: Run SDK tests to confirm no regression**
+
+Run: `cargo test --package tasker-sdk --all-features`
+Expected: All SDK tests pass (the SDK bridges grammar findings unchanged)
+
+- [ ] **Step 5: Final commit if any cleanup needed, otherwise done**
+
+If clippy or formatting requires changes:
+```bash
+cargo fmt --all
+git add -A
+git commit -m "chore(TAS-338): clippy and formatting fixes"
+```

--- a/docs/superpowers/specs/2026-03-20-tas-338-expression-syntax-validation-design.md
+++ b/docs/superpowers/specs/2026-03-20-tas-338-expression-syntax-validation-design.md
@@ -12,23 +12,27 @@
 ## Problem
 
 The `CompositionValidator::check_expression_syntax` method validates jaq expression
-syntax in composition config fields, but only checks **flat string** fields (`data`,
-`params`, `payload`, `condition`, `filter`). Three capabilities — persist, acquire,
-and emit — also accept jaq expressions in **nested `ExpressionField` objects**
-(`validate_success` and `result_shape`), which have the shape
-`{"expression": "<jaq-expression>"}`. These expressions are currently unchecked at
-design time, meaning syntax errors are only caught at runtime.
+syntax in composition config fields, but only handles **flat string** values
+(`if let Some(Value::String(expr)) = invocation.config.get(field)`). In real
+composition configs, **all** expression-bearing fields use the `ExpressionField`
+object shape `{"expression": "<jaq-expression>"}` — including `data`, `params`,
+`payload`, and `condition`, not just `validate_success` and `result_shape`.
 
-All three workflow fixtures (ecommerce, payment reconciliation, customer onboarding)
-use `validate_success` and `result_shape` expressions. This is a meaningful
-validation gap.
+This means the existing flat-string checks are vacuous for real workflow configs.
+The existing validator tests pass only because they use flat strings in test data
+that don't match the actual `ExpressionField` shape used by the typed executor
+configs and all three workflow fixtures.
+
+Additionally, emit's `metadata.correlation_id` and `metadata.idempotency_key`
+contain jaq expressions but are not checked at all.
 
 ## Scope
 
-Extend `check_expression_syntax` in `crates/tasker-grammar/src/validation/validator.rs`
-to validate jaq expressions in nested `ExpressionField` objects alongside existing
-flat string fields. No SDK changes required — the SDK already bridges all grammar-level
-findings through `validate_composition()`.
+Rewrite `check_expression_syntax` in `crates/tasker-grammar/src/validation/validator.rs`
+to extract jaq expressions from both flat strings and `ExpressionField` objects, add
+`validate_success` and `result_shape` to the per-category field lists, and add
+validation for emit metadata expression fields. No SDK changes required — the SDK
+already bridges all grammar-level findings through `validate_composition()`.
 
 ### Out of Scope
 
@@ -45,17 +49,14 @@ value, handling both shapes that appear in capability configs:
 
 | Config shape | Example | Extracted expression |
 |-------------|---------|---------------------|
-| Flat string | `"data": ".prev.order_id"` | `".prev.order_id"` |
-| ExpressionField object | `"validate_success": {"expression": ".affected_rows > 0"}` | `".affected_rows > 0"` |
+| Flat string | `"filter": "{x: .context.name}"` | `"{x: .context.name}"` |
+| ExpressionField object | `"data": {"expression": ".prev.order_id"}` | `".prev.order_id"` |
 | Non-expression value | `"mode": "upsert"` | `None` (skip) |
 
-The helper returns `Option<&str>` — the jaq expression if one is found, `None` otherwise.
-This keeps the main loop clean: iterate fields, extract expression, validate if present.
+The helper returns `Option<&str>` — the jaq expression if one is found, `None`
+otherwise. This keeps the main loop clean: iterate fields, extract, validate.
 
-### Extended field lists
-
-The per-category field lists in `check_expression_syntax` grow to include the nested
-expression fields:
+### Field lists per category
 
 | Category | Fields checked |
 |----------|---------------|
@@ -66,46 +67,68 @@ expression fields:
 | Acquire | `params`, `validate_success`, `result_shape` |
 | Emit | `payload`, `condition`, `validate_success`, `result_shape` |
 
+### Emit metadata expressions
+
+Emit configs can include `metadata.correlation_id` and `metadata.idempotency_key`,
+both `ExpressionField` objects. These are nested one level deeper than other fields
+(`config.metadata.correlation_id.expression`). Add explicit handling: if
+`config.metadata` exists and is an object, check `correlation_id` and
+`idempotency_key` within it using the same extraction helper.
+
 ### Field path in findings
 
-For flat string fields, `field_path` remains `config.<field>` (e.g., `config.data`).
-For nested ExpressionField objects, `field_path` becomes `config.<field>.expression`
-(e.g., `config.validate_success.expression`) to precisely identify the location.
+The `field_path` always reflects the actual location of the expression:
+
+| Field shape | `field_path` value |
+|------------|-------------------|
+| Flat string `filter` | `config.filter` |
+| ExpressionField `data` | `config.data.expression` |
+| ExpressionField `validate_success` | `config.validate_success.expression` |
+| Nested metadata | `config.metadata.correlation_id.expression` |
 
 ### Error format
 
-Unchanged. Same `INVALID_EXPRESSION` error code, same message pattern:
+Same `INVALID_EXPRESSION` error code. Message pattern unchanged:
 ```
-invocation {idx} ({capability}) has invalid jaq expression in '{field}': {parse_error}
+invocation {idx} ({capability}) has invalid jaq expression in '{field_path}': {parse_error}
 ```
+
+The `field_path` in the message now uses the full dotted path (e.g.,
+`config.validate_success.expression`) rather than the simple field name, so users
+can locate the broken expression precisely.
 
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `crates/tasker-grammar/src/validation/validator.rs` | Add expression extraction helper, extend field lists in `check_expression_syntax` |
-| `crates/tasker-grammar/src/validation/tests.rs` | Add test cases for nested expression field validation |
+| `crates/tasker-grammar/src/validation/validator.rs` | Add extraction helper, rewrite `check_expression_syntax` with extended field lists and metadata handling |
+| `crates/tasker-grammar/src/validation/tests.rs` | Update existing tests to use `ExpressionField` shape, add new tests for validate_success/result_shape/metadata |
 
 ## Test Plan
 
+**Updated existing tests** (use `ExpressionField` object shape instead of flat strings):
+
+- `persist_data_expression_validated` — use `{"expression": "broken {{{ syntax"}` shape
+- `emit_payload_expression_validated` — use ExpressionField shape
+- `emit_condition_expression_validated` — use ExpressionField shape
+
 **New tests** (all in `crates/tasker-grammar/src/validation/tests.rs`):
 
-1. `persist_validate_success_expression_validated` — invalid expression in persist validate_success produces `INVALID_EXPRESSION` error
-2. `persist_result_shape_expression_validated` — invalid expression in persist result_shape produces error
-3. `acquire_validate_success_expression_validated` — invalid expression in acquire validate_success produces error
-4. `acquire_result_shape_expression_validated` — invalid expression in acquire result_shape produces error
-5. `emit_validate_success_expression_validated` — invalid expression in emit validate_success produces error
-6. `emit_result_shape_expression_validated` — invalid expression in emit result_shape produces error
-7. `valid_nested_expressions_pass` — valid expressions in ExpressionField objects produce no findings
+1. `persist_validate_success_expression_validated` — invalid expression in persist validate_success
+2. `persist_result_shape_expression_validated` — invalid expression in persist result_shape
+3. `acquire_validate_success_expression_validated` — invalid expression in acquire validate_success
+4. `acquire_result_shape_expression_validated` — invalid expression in acquire result_shape
+5. `emit_validate_success_expression_validated` — invalid expression in emit validate_success
+6. `emit_result_shape_expression_validated` — invalid expression in emit result_shape
+7. `emit_metadata_correlation_id_expression_validated` — invalid expression in metadata.correlation_id
+8. `emit_metadata_idempotency_key_expression_validated` — invalid expression in metadata.idempotency_key
+9. `valid_nested_expressions_pass` — valid ExpressionField objects produce no findings
 
 **Existing coverage** (unchanged, confirms no regressions):
 
-- `invalid_jaq_expression_produces_error` — transform filter
+- `invalid_jaq_expression_produces_error` — transform filter (flat string, correct for transform)
 - `valid_jaq_expression_passes` — transform filter
-- `assert_filter_syntax_validated` — assert filter
-- `persist_data_expression_validated` — persist data
-- `emit_payload_expression_validated` — emit payload
-- `emit_condition_expression_validated` — emit condition
+- `assert_filter_syntax_validated` — assert filter (flat string, correct for assert)
 - Workflow fixture integration tests (3 fixtures validated end-to-end via TAS-337)
 
 ## Verification

--- a/docs/superpowers/specs/2026-03-20-tas-338-expression-syntax-validation-design.md
+++ b/docs/superpowers/specs/2026-03-20-tas-338-expression-syntax-validation-design.md
@@ -1,0 +1,122 @@
+# TAS-338: Expression Syntax Validation for Composition Templates
+
+**Date**: 2026-03-20
+**Status**: Approved
+**Ticket**: TAS-338
+**Roadmap Lane**: 3C (Validation Tooling)
+**Predecessor**: TAS-321 (jaq-core expression engine), TAS-333 (CompositionValidator)
+**Related**: TAS-337 (composition-aware template validator)
+
+---
+
+## Problem
+
+The `CompositionValidator::check_expression_syntax` method validates jaq expression
+syntax in composition config fields, but only checks **flat string** fields (`data`,
+`params`, `payload`, `condition`, `filter`). Three capabilities — persist, acquire,
+and emit — also accept jaq expressions in **nested `ExpressionField` objects**
+(`validate_success` and `result_shape`), which have the shape
+`{"expression": "<jaq-expression>"}`. These expressions are currently unchecked at
+design time, meaning syntax errors are only caught at runtime.
+
+All three workflow fixtures (ecommerce, payment reconciliation, customer onboarding)
+use `validate_success` and `result_shape` expressions. This is a meaningful
+validation gap.
+
+## Scope
+
+Extend `check_expression_syntax` in `crates/tasker-grammar/src/validation/validator.rs`
+to validate jaq expressions in nested `ExpressionField` objects alongside existing
+flat string fields. No SDK changes required — the SDK already bridges all grammar-level
+findings through `validate_composition()`.
+
+### Out of Scope
+
+- Expression variable resolution (TAS-341: checks whether `.prev.field` actually exists)
+- Expression result type validation (semantic analysis beyond syntax)
+- New capability categories or config field additions
+
+## Design
+
+### Expression extraction helper
+
+Add a private helper function to extract a jaq expression string from a config field
+value, handling both shapes that appear in capability configs:
+
+| Config shape | Example | Extracted expression |
+|-------------|---------|---------------------|
+| Flat string | `"data": ".prev.order_id"` | `".prev.order_id"` |
+| ExpressionField object | `"validate_success": {"expression": ".affected_rows > 0"}` | `".affected_rows > 0"` |
+| Non-expression value | `"mode": "upsert"` | `None` (skip) |
+
+The helper returns `Option<&str>` — the jaq expression if one is found, `None` otherwise.
+This keeps the main loop clean: iterate fields, extract expression, validate if present.
+
+### Extended field lists
+
+The per-category field lists in `check_expression_syntax` grow to include the nested
+expression fields:
+
+| Category | Fields checked |
+|----------|---------------|
+| Transform | `filter` |
+| Assert | `filter` |
+| Validate | *(none)* |
+| Persist | `data`, `validate_success`, `result_shape` |
+| Acquire | `params`, `validate_success`, `result_shape` |
+| Emit | `payload`, `condition`, `validate_success`, `result_shape` |
+
+### Field path in findings
+
+For flat string fields, `field_path` remains `config.<field>` (e.g., `config.data`).
+For nested ExpressionField objects, `field_path` becomes `config.<field>.expression`
+(e.g., `config.validate_success.expression`) to precisely identify the location.
+
+### Error format
+
+Unchanged. Same `INVALID_EXPRESSION` error code, same message pattern:
+```
+invocation {idx} ({capability}) has invalid jaq expression in '{field}': {parse_error}
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/tasker-grammar/src/validation/validator.rs` | Add expression extraction helper, extend field lists in `check_expression_syntax` |
+| `crates/tasker-grammar/src/validation/tests.rs` | Add test cases for nested expression field validation |
+
+## Test Plan
+
+**New tests** (all in `crates/tasker-grammar/src/validation/tests.rs`):
+
+1. `persist_validate_success_expression_validated` — invalid expression in persist validate_success produces `INVALID_EXPRESSION` error
+2. `persist_result_shape_expression_validated` — invalid expression in persist result_shape produces error
+3. `acquire_validate_success_expression_validated` — invalid expression in acquire validate_success produces error
+4. `acquire_result_shape_expression_validated` — invalid expression in acquire result_shape produces error
+5. `emit_validate_success_expression_validated` — invalid expression in emit validate_success produces error
+6. `emit_result_shape_expression_validated` — invalid expression in emit result_shape produces error
+7. `valid_nested_expressions_pass` — valid expressions in ExpressionField objects produce no findings
+
+**Existing coverage** (unchanged, confirms no regressions):
+
+- `invalid_jaq_expression_produces_error` — transform filter
+- `valid_jaq_expression_passes` — transform filter
+- `assert_filter_syntax_validated` — assert filter
+- `persist_data_expression_validated` — persist data
+- `emit_payload_expression_validated` — emit payload
+- `emit_condition_expression_validated` — emit condition
+- Workflow fixture integration tests (3 fixtures validated end-to-end via TAS-337)
+
+## Verification
+
+```bash
+# Grammar tests pass
+cargo test --package tasker-grammar --all-features
+
+# Full workspace compiles
+cargo check --all-features --workspace
+
+# Zero clippy warnings
+cargo clippy --all-targets --all-features --workspace
+```


### PR DESCRIPTION
## Summary

- Add `extract_expression` helper that handles both flat string and `ExpressionField` object (`{"expression": "..."}`) shapes in composition configs
- Extend `check_expression_syntax` to validate `validate_success` and `result_shape` jaq expressions for persist, acquire, and emit capabilities
- Add emit metadata expression validation for `correlation_id` and `idempotency_key`
- Fix existing expression tests to use real `ExpressionField` object shape (previous flat-string checks were vacuous for actual workflow configs)

## Details

The spec review caught a significant blindspot: the existing `check_expression_syntax` only checked `Value::String` fields, but real composition configs (and all 3 workflow fixtures) use `{"expression": "..."}` objects for `data`, `params`, `payload`, and `condition`. The flat-string checks were passing in tests but never matching real configs.

This PR fixes that gap and extends coverage to all expression-bearing config fields.

## Test plan

- [x] 9 new tests covering validate_success/result_shape (6), emit metadata (2), and valid-expressions-pass (1)
- [x] 3 existing tests updated to use ExpressionField object shape with field_path assertions
- [x] Test registry schemas updated to accept both string and object types
- [x] 504 grammar tests passing (457 lib + 30 integration + 17 doc)
- [x] All SDK tests passing (no regression)
- [x] Zero clippy warnings across workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)