### PR TITLE
feat(TAS-344): composition_explain trace for data flow visualization

### DIFF
--- a/crates/tasker-ctl/Cargo.toml
+++ b/crates/tasker-ctl/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 # Workspace crates
 tasker-client = { path = "../tasker-client", version = "=0.1.8" }
+tasker-grammar = { path = "../tasker-grammar" }
 tasker-shared = { path = "../tasker-shared", version = "=0.1.8" }
 tasker-sdk = { path = "../tasker-sdk", version = "=0.1.8" }
 

--- a/crates/tasker-ctl/src/commands/grammar.rs
+++ b/crates/tasker-ctl/src/commands/grammar.rs
@@ -67,6 +67,32 @@ pub(crate) enum CompositionCommands {
         #[arg(long)]
         step: Option<String>,
     },
+
+    /// Explain data flow through a composition spec file
+    Explain {
+        /// Path to the composition file
+        path: PathBuf,
+
+        /// Explain only the named step's composition within a full task template
+        #[arg(long)]
+        step: Option<String>,
+
+        /// Sample context data (inline JSON or @path/to/file.json)
+        #[arg(long)]
+        sample_context: Option<String>,
+
+        /// Sample dependency results (inline JSON or @path/to/file.json)
+        #[arg(long)]
+        sample_deps: Option<String>,
+
+        /// Sample step metadata (inline JSON or @path/to/file.json)
+        #[arg(long)]
+        sample_step: Option<String>,
+
+        /// Mock outputs for side-effecting invocations (inline JSON or @path/to/file.json)
+        #[arg(long)]
+        mock_outputs: Option<String>,
+    },
 }
 
 /// Dispatch a grammar command to the appropriate handler.
@@ -85,6 +111,22 @@ pub(crate) async fn handle_grammar_command(cmd: GrammarCommands, format: &str) -
             CompositionCommands::Validate { path, step } => {
                 composition_validate(&path, step.as_deref(), format)
             }
+            CompositionCommands::Explain {
+                path,
+                step,
+                sample_context,
+                sample_deps,
+                sample_step,
+                mock_outputs,
+            } => composition_explain(
+                &path,
+                step.as_deref(),
+                sample_context.as_deref(),
+                sample_deps.as_deref(),
+                sample_step.as_deref(),
+                mock_outputs.as_deref(),
+                format,
+            ),
         },
     }
 }
@@ -359,6 +401,191 @@ fn composition_validate(path: &PathBuf, step: Option<&str>, format: &str) -> Cli
 
     if !report.valid {
         std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Load a JSON argument: if it starts with `@`, read from file; otherwise parse as inline JSON.
+fn load_json_arg(value: &str) -> ClientResult<serde_json::Value> {
+    let content = if let Some(path) = value.strip_prefix('@') {
+        std::fs::read_to_string(path).map_err(|e| {
+            tasker_client::ClientError::Internal(format!("Failed to read {path}: {e}"))
+        })?
+    } else {
+        value.to_owned()
+    };
+    serde_json::from_str(&content)
+        .map_err(|e| tasker_client::ClientError::Internal(format!("Invalid JSON: {e}")))
+}
+
+fn composition_explain(
+    path: &PathBuf,
+    step: Option<&str>,
+    sample_context: Option<&str>,
+    sample_deps: Option<&str>,
+    sample_step: Option<&str>,
+    mock_outputs: Option<&str>,
+    format: &str,
+) -> ClientResult<()> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| tasker_client::ClientError::Internal(format!("Failed to read file: {e}")))?;
+
+    // If --step provided, extract the step's composition from a full template
+    let yaml_to_explain = if let Some(step_name) = step {
+        let template = tasker_sdk::template_parser::parse_template_str(&content).map_err(|e| {
+            tasker_client::ClientError::Internal(format!(
+                "Failed to parse template '{}': {e}",
+                path.display()
+            ))
+        })?;
+
+        let step_def = template
+            .steps
+            .iter()
+            .find(|s| s.name == step_name)
+            .ok_or_else(|| {
+                tasker_client::ClientError::Internal(format!(
+                    "Step '{step_name}' not found in template"
+                ))
+            })?;
+
+        let composition_value = step_def.composition.as_ref().ok_or_else(|| {
+            tasker_client::ClientError::Internal(format!(
+                "Step '{step_name}' has no composition field"
+            ))
+        })?;
+
+        serde_yaml::to_string(composition_value).map_err(|e| {
+            tasker_client::ClientError::Internal(format!(
+                "Failed to serialize composition for step '{step_name}': {e}"
+            ))
+        })?
+    } else {
+        content
+    };
+
+    // Build SimulationInput if any sample data provided
+    let simulation = if sample_context.is_some()
+        || sample_deps.is_some()
+        || sample_step.is_some()
+        || mock_outputs.is_some()
+    {
+        let ctx = sample_context
+            .map(load_json_arg)
+            .transpose()?
+            .unwrap_or(serde_json::Value::Null);
+        let deps = sample_deps
+            .map(load_json_arg)
+            .transpose()?
+            .unwrap_or(serde_json::Value::Null);
+        let step_meta = sample_step
+            .map(load_json_arg)
+            .transpose()?
+            .unwrap_or(serde_json::Value::Null);
+        let mocks: std::collections::HashMap<usize, serde_json::Value> = mock_outputs
+            .map(load_json_arg)
+            .transpose()?
+            .and_then(|v| {
+                v.as_object().map(|map| {
+                    map.iter()
+                        .filter_map(|(k, v)| k.parse::<usize>().ok().map(|idx| (idx, v.clone())))
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+
+        Some(tasker_grammar::SimulationInput {
+            context: ctx,
+            deps,
+            step: step_meta,
+            mock_outputs: mocks,
+        })
+    } else {
+        None
+    };
+
+    let explanation = tasker_sdk::grammar_query::explain_composition(&yaml_to_explain, simulation);
+
+    if format == "json" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&explanation)
+                .map_err(|e| tasker_client::ClientError::Internal(e.to_string()))?
+        );
+    } else {
+        // Table output: show invocation chain summary
+        if let Some(ref name) = explanation.name {
+            output::header(format!("Composition: {name}"));
+        } else {
+            output::header("Composition Explain");
+        }
+
+        println!("Outcome: {}", explanation.outcome.description);
+        if explanation.simulated {
+            output::success("Simulation mode (sample data provided)");
+        }
+        println!();
+
+        // Show invocation chain
+        if !explanation.invocations.is_empty() {
+            println!(
+                "  {:<5} {:<12} {:<12} {:<10} {:<30} {:<5}",
+                "Index", "Capability", "Category", "Checkpoint", ".prev source", "Exprs"
+            );
+            println!("  {}", "-".repeat(75));
+
+            for inv in &explanation.invocations {
+                let prev_src = inv
+                    .envelope_available
+                    .prev_source
+                    .as_deref()
+                    .unwrap_or("(none)");
+                let checkpoint = if inv.checkpoint { "yes" } else { "no" };
+                println!(
+                    "  {:<5} {:<12} {:<12} {:<10} {:<30} {:<5}",
+                    inv.index,
+                    inv.capability,
+                    inv.category,
+                    checkpoint,
+                    prev_src,
+                    inv.expressions.len()
+                );
+
+                // Show simulated values if present
+                if let Some(ref output) = inv.simulated_output {
+                    println!(
+                        "         → simulated output: {}",
+                        serde_json::to_string(output).unwrap_or_else(|_| "?".to_owned())
+                    );
+                }
+            }
+        }
+
+        // Show findings if any
+        if !explanation.findings.is_empty() {
+            println!();
+            for finding in &explanation.findings {
+                let prefix = match finding.severity.as_str() {
+                    "error" => "  ERROR",
+                    "warning" => "  WARN ",
+                    _ => "  INFO ",
+                };
+                let location = match (&finding.invocation_index, &finding.field_path) {
+                    (Some(idx), Some(field)) => format!(" [invocation {idx}, {field}]"),
+                    (Some(idx), None) => format!(" [invocation {idx}]"),
+                    _ => String::new(),
+                };
+                println!(
+                    "{prefix}{location}: [{code}] {msg}",
+                    code = finding.code,
+                    msg = finding.message
+                );
+            }
+        }
+
+        println!();
+        output::dim(&explanation.summary);
     }
 
     Ok(())

--- a/crates/tasker-grammar/Cargo.toml
+++ b/crates/tasker-grammar/Cargo.toml
@@ -22,6 +22,7 @@ jsonschema = "0.28"
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+regex = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }

--- a/crates/tasker-grammar/src/explain/analyzer.rs
+++ b/crates/tasker-grammar/src/explain/analyzer.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
+
 use serde_json::Value;
 
 use crate::explain::types::{
     EnvelopeSnapshot, ExplanationTrace, ExpressionReference, InvocationTrace, OutcomeSummary,
     SimulationInput,
 };
-use crate::types::{CompositionSpec, GrammarCategoryKind, MutationProfile};
+use crate::types::{
+    CompositionSpec, GrammarCategoryKind, MutationProfile, Severity, ValidationFinding,
+};
 use crate::validation::{CapabilityRegistry, CompositionValidator};
 use crate::ExpressionEngine;
 
@@ -36,6 +40,35 @@ fn extract_expression(value: &Value) -> Option<&str> {
         .and_then(|v| v.as_str())
 }
 
+/// Build the envelope for expression evaluation, matching the executor's shape.
+fn build_envelope(
+    context: &Value,
+    deps: &Value,
+    step: &Value,
+    prev: &Value,
+    accumulated: &HashMap<usize, Value>,
+) -> Value {
+    let invocation_outputs: serde_json::Map<String, Value> = accumulated
+        .iter()
+        .map(|(idx, output)| (idx.to_string(), output.clone()))
+        .collect();
+
+    let mut deps_with_invocations = match deps {
+        Value::Object(map) => map.clone(),
+        _ => serde_json::Map::new(),
+    };
+    if !invocation_outputs.is_empty() {
+        deps_with_invocations.insert("invocations".to_owned(), Value::Object(invocation_outputs));
+    }
+
+    serde_json::json!({
+        "context": context,
+        "deps": deps_with_invocations,
+        "step": step,
+        "prev": prev,
+    })
+}
+
 impl<'a> ExplainAnalyzer<'a> {
     /// Create a new analyzer with the given capability registry and expression engine.
     pub fn new(
@@ -50,19 +83,37 @@ impl<'a> ExplainAnalyzer<'a> {
 
     /// Produce a static analysis trace (no expression evaluation).
     pub fn analyze(&self, spec: &CompositionSpec) -> ExplanationTrace {
+        self.analyze_internal(spec, None)
+    }
+
+    /// Produce a trace with simulated expression evaluation.
+    pub fn analyze_with_simulation(
+        &self,
+        spec: &CompositionSpec,
+        input: &SimulationInput,
+    ) -> ExplanationTrace {
+        self.analyze_internal(spec, Some(input))
+    }
+
+    /// Shared implementation for both static analysis and simulated evaluation.
+    fn analyze_internal(
+        &self,
+        spec: &CompositionSpec,
+        simulation: Option<&SimulationInput>,
+    ) -> ExplanationTrace {
+        let is_simulated = simulation.is_some();
+
         // Run validator and capture findings
         let validator = CompositionValidator::new(self.registry, self.expression_engine);
         let validation_result = validator.validate(spec);
-        let findings = validation_result.findings;
+        let mut findings = validation_result.findings;
 
         let outcome = OutcomeSummary {
             description: spec.outcome.description.clone(),
             output_schema: spec.outcome.output_schema.clone(),
         };
 
-        // Handle degenerate cases: empty or over-limit compositions
-        // The validator already returns early for these, so findings will have the error.
-        // We detect this by checking if any finding is a terminal structural error.
+        // Handle degenerate cases
         let is_degenerate = findings
             .iter()
             .any(|f| f.code == "EMPTY_COMPOSITION" || f.code == "TOO_MANY_INVOCATIONS");
@@ -73,7 +124,7 @@ impl<'a> ExplainAnalyzer<'a> {
                 outcome,
                 invocations: vec![],
                 validation: findings,
-                simulated: false,
+                simulated: is_simulated,
             };
         }
 
@@ -81,6 +132,10 @@ impl<'a> ExplainAnalyzer<'a> {
         let mut invocation_traces = Vec::with_capacity(spec.invocations.len());
         let mut prev_schema: Option<Value> = None;
         let mut prev_source: Option<String> = None;
+
+        // Simulation state: tracked .prev value and accumulated outputs
+        let mut sim_prev: Value = Value::Null;
+        let mut accumulated: HashMap<usize, Value> = HashMap::new();
 
         for (idx, invocation) in spec.invocations.iter().enumerate() {
             let decl = self.registry.get_capability(&invocation.capability);
@@ -109,13 +164,24 @@ impl<'a> ExplainAnalyzer<'a> {
                     simulated_output: None,
                     mock_output_used: false,
                 });
-                // Don't update prev_schema — unknown capability produces no output
                 prev_schema = None;
                 prev_source = None;
+                sim_prev = Value::Null;
                 continue;
             };
 
             let is_mutating = matches!(decl.mutation_profile, MutationProfile::Mutating { .. });
+
+            // Build the simulation envelope if in simulation mode
+            let sim_envelope = simulation.map(|input| {
+                build_envelope(
+                    &input.context,
+                    &input.deps,
+                    &input.step,
+                    &sim_prev,
+                    &accumulated,
+                )
+            });
 
             // Extract expressions from category-specific config fields
             let expression_fields: &[&str] = match decl.grammar_category {
@@ -144,11 +210,31 @@ impl<'a> ExplainAnalyzer<'a> {
                         .extract_references(expr)
                         .unwrap_or_default();
 
+                    // Evaluate expression against simulation envelope if available
+                    let simulated_result = sim_envelope.as_ref().and_then(|env| {
+                        match self.expression_engine.evaluate(expr, env) {
+                            Ok(result) => Some(result),
+                            Err(_) => {
+                                findings.push(ValidationFinding {
+                                    severity: Severity::Warning,
+                                    code: "SIMULATION_EVAL_FAILURE".to_owned(),
+                                    invocation_index: Some(idx),
+                                    message: format!(
+                                        "Expression evaluation failed for '{}' at invocation {}",
+                                        expr, idx
+                                    ),
+                                    field_path: Some(field_path.clone()),
+                                });
+                                None
+                            }
+                        }
+                    });
+
                     expressions.push(ExpressionReference {
                         field_path,
                         expression: expr.to_owned(),
                         referenced_paths,
-                        simulated_result: None,
+                        simulated_result,
                     });
                 }
             }
@@ -166,11 +252,15 @@ impl<'a> ExplainAnalyzer<'a> {
                                     .extract_references(expr)
                                     .unwrap_or_default();
 
+                                let simulated_result = sim_envelope.as_ref().and_then(|env| {
+                                    self.expression_engine.evaluate(expr, env).ok()
+                                });
+
                                 expressions.push(ExpressionReference {
                                     field_path,
                                     expression: expr.to_owned(),
                                     referenced_paths,
-                                    simulated_result: None,
+                                    simulated_result,
                                 });
                             }
                         }
@@ -181,7 +271,27 @@ impl<'a> ExplainAnalyzer<'a> {
             // Extract declared output schema
             let output_schema = self.extract_output_schema(invocation, decl);
 
-            // Track for next invocation's envelope
+            // Compute simulated output and update sim_prev for next invocation
+            let (simulated_output, mock_output_used) = if let Some(sim_input) = simulation {
+                self.compute_simulation_output(
+                    idx,
+                    decl.grammar_category,
+                    &expressions,
+                    &sim_prev,
+                    sim_input,
+                    &mut findings,
+                )
+            } else {
+                (None, false)
+            };
+
+            // Update sim_prev for next invocation
+            if let Some(ref output) = simulated_output {
+                sim_prev = output.clone();
+                accumulated.insert(idx, output.clone());
+            }
+
+            // Track for next invocation's envelope (static schema tracking)
             if let Some(ref schema) = output_schema {
                 prev_schema = Some(schema.clone());
                 prev_source = Some(format!(
@@ -189,9 +299,8 @@ impl<'a> ExplainAnalyzer<'a> {
                     idx, invocation.capability
                 ));
             } else {
-                // Assert passes .prev through unchanged; others don't declare output
                 match decl.grammar_category {
-                    GrammarCategoryKind::Assert => {
+                    GrammarCategoryKind::Assert | GrammarCategoryKind::Validate => {
                         // prev_schema and prev_source remain unchanged
                     }
                     _ => {
@@ -210,8 +319,8 @@ impl<'a> ExplainAnalyzer<'a> {
                 envelope_available: envelope,
                 expressions,
                 output_schema,
-                simulated_output: None,
-                mock_output_used: false,
+                simulated_output,
+                mock_output_used,
             });
         }
 
@@ -220,17 +329,63 @@ impl<'a> ExplainAnalyzer<'a> {
             outcome,
             invocations: invocation_traces,
             validation: findings,
-            simulated: false,
+            simulated: is_simulated,
         }
     }
 
-    /// Produce a trace with simulated expression evaluation.
-    pub fn analyze_with_simulation(
+    /// Compute simulated output for an invocation based on its category.
+    ///
+    /// Returns `(simulated_output, mock_output_used)`.
+    fn compute_simulation_output(
         &self,
-        _spec: &CompositionSpec,
-        _input: &SimulationInput,
-    ) -> ExplanationTrace {
-        todo!("Task 4 implements this")
+        idx: usize,
+        category: GrammarCategoryKind,
+        expressions: &[ExpressionReference],
+        prev: &Value,
+        input: &SimulationInput,
+        findings: &mut Vec<ValidationFinding>,
+    ) -> (Option<Value>, bool) {
+        match category {
+            // Transform: the filter expression result IS the simulated output
+            GrammarCategoryKind::Transform => {
+                let output = expressions
+                    .first()
+                    .and_then(|expr_ref| expr_ref.simulated_result.clone())
+                    .unwrap_or(Value::Null);
+                (Some(output), false)
+            }
+            // Assert and Validate: pass .prev through unchanged
+            GrammarCategoryKind::Assert | GrammarCategoryKind::Validate => {
+                (Some(prev.clone()), false)
+            }
+            // Side-effecting: use mock output or null
+            GrammarCategoryKind::Persist
+            | GrammarCategoryKind::Acquire
+            | GrammarCategoryKind::Emit => {
+                if let Some(mock) = input.mock_outputs.get(&idx) {
+                    (Some(mock.clone()), true)
+                } else {
+                    findings.push(ValidationFinding {
+                        severity: Severity::Info,
+                        code: "MISSING_MOCK_OUTPUT".to_owned(),
+                        invocation_index: Some(idx),
+                        message: format!(
+                            "No mock output provided for side-effecting invocation {} ({}); \
+                             .prev will be null for subsequent invocations",
+                            idx,
+                            match category {
+                                GrammarCategoryKind::Persist => "persist",
+                                GrammarCategoryKind::Acquire => "acquire",
+                                GrammarCategoryKind::Emit => "emit",
+                                _ => unreachable!(),
+                            }
+                        ),
+                        field_path: None,
+                    });
+                    (Some(Value::Null), false)
+                }
+            }
+        }
     }
 
     /// Extract the output schema declared by an invocation, if any.

--- a/crates/tasker-grammar/src/explain/analyzer.rs
+++ b/crates/tasker-grammar/src/explain/analyzer.rs
@@ -1,0 +1,46 @@
+use crate::explain::types::{ExplanationTrace, SimulationInput};
+use crate::types::CompositionSpec;
+use crate::validation::CapabilityRegistry;
+use crate::ExpressionEngine;
+
+/// Analyzes a CompositionSpec to produce a data flow trace.
+pub struct ExplainAnalyzer<'a> {
+    #[expect(dead_code, reason = "used in Task 3 static analysis implementation")]
+    registry: &'a dyn CapabilityRegistry,
+    expression_engine: &'a ExpressionEngine,
+}
+
+impl std::fmt::Debug for ExplainAnalyzer<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExplainAnalyzer")
+            .field("expression_engine", &self.expression_engine)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> ExplainAnalyzer<'a> {
+    /// Create a new analyzer with the given capability registry and expression engine.
+    pub fn new(
+        registry: &'a dyn CapabilityRegistry,
+        expression_engine: &'a ExpressionEngine,
+    ) -> Self {
+        Self {
+            registry,
+            expression_engine,
+        }
+    }
+
+    /// Produce a static analysis trace (no expression evaluation).
+    pub fn analyze(&self, _spec: &CompositionSpec) -> ExplanationTrace {
+        todo!("Task 3 implements this")
+    }
+
+    /// Produce a trace with simulated expression evaluation.
+    pub fn analyze_with_simulation(
+        &self,
+        _spec: &CompositionSpec,
+        _input: &SimulationInput,
+    ) -> ExplanationTrace {
+        todo!("Task 4 implements this")
+    }
+}

--- a/crates/tasker-grammar/src/explain/analyzer.rs
+++ b/crates/tasker-grammar/src/explain/analyzer.rs
@@ -1,11 +1,15 @@
-use crate::explain::types::{ExplanationTrace, SimulationInput};
-use crate::types::CompositionSpec;
-use crate::validation::CapabilityRegistry;
+use serde_json::Value;
+
+use crate::explain::types::{
+    EnvelopeSnapshot, ExplanationTrace, ExpressionReference, InvocationTrace, OutcomeSummary,
+    SimulationInput,
+};
+use crate::types::{CompositionSpec, GrammarCategoryKind, MutationProfile};
+use crate::validation::{CapabilityRegistry, CompositionValidator};
 use crate::ExpressionEngine;
 
 /// Analyzes a CompositionSpec to produce a data flow trace.
 pub struct ExplainAnalyzer<'a> {
-    #[expect(dead_code, reason = "used in Task 3 static analysis implementation")]
     registry: &'a dyn CapabilityRegistry,
     expression_engine: &'a ExpressionEngine,
 }
@@ -16,6 +20,20 @@ impl std::fmt::Debug for ExplainAnalyzer<'_> {
             .field("expression_engine", &self.expression_engine)
             .finish_non_exhaustive()
     }
+}
+
+/// Handles two shapes:
+/// - Flat string: `"filter": ".context.name"` → `Some(".context.name")`
+/// - ExpressionField object: `"data": {"expression": ".prev"}` → `Some(".prev")`
+/// - Anything else: `None`
+fn extract_expression(value: &Value) -> Option<&str> {
+    if let Some(s) = value.as_str() {
+        return Some(s);
+    }
+    value
+        .as_object()
+        .and_then(|obj| obj.get("expression"))
+        .and_then(|v| v.as_str())
 }
 
 impl<'a> ExplainAnalyzer<'a> {
@@ -31,8 +49,179 @@ impl<'a> ExplainAnalyzer<'a> {
     }
 
     /// Produce a static analysis trace (no expression evaluation).
-    pub fn analyze(&self, _spec: &CompositionSpec) -> ExplanationTrace {
-        todo!("Task 3 implements this")
+    pub fn analyze(&self, spec: &CompositionSpec) -> ExplanationTrace {
+        // Run validator and capture findings
+        let validator = CompositionValidator::new(self.registry, self.expression_engine);
+        let validation_result = validator.validate(spec);
+        let findings = validation_result.findings;
+
+        let outcome = OutcomeSummary {
+            description: spec.outcome.description.clone(),
+            output_schema: spec.outcome.output_schema.clone(),
+        };
+
+        // Handle degenerate cases: empty or over-limit compositions
+        // The validator already returns early for these, so findings will have the error.
+        // We detect this by checking if any finding is a terminal structural error.
+        let is_degenerate = findings
+            .iter()
+            .any(|f| f.code == "EMPTY_COMPOSITION" || f.code == "TOO_MANY_INVOCATIONS");
+
+        if is_degenerate {
+            return ExplanationTrace {
+                name: spec.name.clone(),
+                outcome,
+                invocations: vec![],
+                validation: findings,
+                simulated: false,
+            };
+        }
+
+        // Walk invocations in order, building trace entries
+        let mut invocation_traces = Vec::with_capacity(spec.invocations.len());
+        let mut prev_schema: Option<Value> = None;
+        let mut prev_source: Option<String> = None;
+
+        for (idx, invocation) in spec.invocations.iter().enumerate() {
+            let decl = self.registry.get_capability(&invocation.capability);
+
+            // Build envelope snapshot
+            let envelope = EnvelopeSnapshot {
+                context: true,
+                deps: true,
+                step: true,
+                has_prev: prev_schema.is_some() || prev_source.is_some(),
+                prev_source: prev_source.clone(),
+                prev_schema: prev_schema.clone(),
+            };
+
+            // If capability not found, produce partial trace entry
+            let Some(decl) = decl else {
+                invocation_traces.push(InvocationTrace {
+                    index: idx,
+                    capability: invocation.capability.clone(),
+                    category: GrammarCategoryKind::Transform, // default; unknown
+                    checkpoint: invocation.checkpoint,
+                    is_mutating: false,
+                    envelope_available: envelope,
+                    expressions: vec![],
+                    output_schema: None,
+                    simulated_output: None,
+                    mock_output_used: false,
+                });
+                // Don't update prev_schema — unknown capability produces no output
+                prev_schema = None;
+                prev_source = None;
+                continue;
+            };
+
+            let is_mutating = matches!(decl.mutation_profile, MutationProfile::Mutating { .. });
+
+            // Extract expressions from category-specific config fields
+            let expression_fields: &[&str] = match decl.grammar_category {
+                GrammarCategoryKind::Transform => &["filter"],
+                GrammarCategoryKind::Assert => &["filter"],
+                GrammarCategoryKind::Persist => &["data", "validate_success", "result_shape"],
+                GrammarCategoryKind::Acquire => &["params", "validate_success", "result_shape"],
+                GrammarCategoryKind::Emit => {
+                    &["payload", "condition", "validate_success", "result_shape"]
+                }
+                GrammarCategoryKind::Validate => &[],
+            };
+
+            let mut expressions = Vec::new();
+
+            for field in expression_fields {
+                if let Some(value) = invocation.config.get(*field) {
+                    let (expr, field_path) = match extract_expression(value) {
+                        Some(e) if value.is_string() => (e, format!("config.{field}")),
+                        Some(e) => (e, format!("config.{field}.expression")),
+                        None => continue,
+                    };
+
+                    let referenced_paths = self
+                        .expression_engine
+                        .extract_references(expr)
+                        .unwrap_or_default();
+
+                    expressions.push(ExpressionReference {
+                        field_path,
+                        expression: expr.to_owned(),
+                        referenced_paths,
+                        simulated_result: None,
+                    });
+                }
+            }
+
+            // Emit metadata expressions (nested one level deeper)
+            if matches!(decl.grammar_category, GrammarCategoryKind::Emit) {
+                if let Some(metadata) = invocation.config.get("metadata").and_then(Value::as_object)
+                {
+                    for meta_field in &["correlation_id", "idempotency_key"] {
+                        if let Some(value) = metadata.get(*meta_field) {
+                            if let Some(expr) = extract_expression(value) {
+                                let field_path = format!("config.metadata.{meta_field}.expression");
+                                let referenced_paths = self
+                                    .expression_engine
+                                    .extract_references(expr)
+                                    .unwrap_or_default();
+
+                                expressions.push(ExpressionReference {
+                                    field_path,
+                                    expression: expr.to_owned(),
+                                    referenced_paths,
+                                    simulated_result: None,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Extract declared output schema
+            let output_schema = self.extract_output_schema(invocation, decl);
+
+            // Track for next invocation's envelope
+            if let Some(ref schema) = output_schema {
+                prev_schema = Some(schema.clone());
+                prev_source = Some(format!(
+                    "output of invocation {} ({})",
+                    idx, invocation.capability
+                ));
+            } else {
+                // Assert passes .prev through unchanged; others don't declare output
+                match decl.grammar_category {
+                    GrammarCategoryKind::Assert => {
+                        // prev_schema and prev_source remain unchanged
+                    }
+                    _ => {
+                        prev_schema = None;
+                        prev_source = None;
+                    }
+                }
+            }
+
+            invocation_traces.push(InvocationTrace {
+                index: idx,
+                capability: invocation.capability.clone(),
+                category: decl.grammar_category,
+                checkpoint: invocation.checkpoint,
+                is_mutating,
+                envelope_available: envelope,
+                expressions,
+                output_schema,
+                simulated_output: None,
+                mock_output_used: false,
+            });
+        }
+
+        ExplanationTrace {
+            name: spec.name.clone(),
+            outcome,
+            invocations: invocation_traces,
+            validation: findings,
+            simulated: false,
+        }
     }
 
     /// Produce a trace with simulated expression evaluation.
@@ -42,5 +231,22 @@ impl<'a> ExplainAnalyzer<'a> {
         _input: &SimulationInput,
     ) -> ExplanationTrace {
         todo!("Task 4 implements this")
+    }
+
+    /// Extract the output schema declared by an invocation, if any.
+    fn extract_output_schema(
+        &self,
+        invocation: &crate::types::CapabilityInvocation,
+        decl: &crate::types::CapabilityDeclaration,
+    ) -> Option<Value> {
+        match decl.grammar_category {
+            GrammarCategoryKind::Transform => invocation
+                .config
+                .get("output")
+                .filter(|v| !v.is_null() && v.as_object().is_some_and(|o| !o.is_empty()))
+                .cloned(),
+            GrammarCategoryKind::Assert => None,
+            _ => None,
+        }
     }
 }

--- a/crates/tasker-grammar/src/explain/mod.rs
+++ b/crates/tasker-grammar/src/explain/mod.rs
@@ -1,0 +1,23 @@
+//! Composition explanation and data flow tracing.
+//!
+//! The [`ExplainAnalyzer`] produces an [`ExplanationTrace`] that visualizes how
+//! data flows through a composition's invocation chain. Two modes:
+//!
+//! - **Static analysis**: traces structure, envelope field availability, expression
+//!   references, output schemas, and checkpoint placement.
+//! - **Simulated evaluation**: when [`SimulationInput`] is provided, evaluates jaq
+//!   expressions against sample data and threads computed results through the chain.
+//!
+//! **Ticket**: TAS-344
+
+mod analyzer;
+mod types;
+
+pub use analyzer::ExplainAnalyzer;
+pub use types::{
+    EnvelopeSnapshot, ExplanationTrace, ExpressionReference, InvocationTrace, OutcomeSummary,
+    SimulationInput,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/tasker-grammar/src/explain/tests.rs
+++ b/crates/tasker-grammar/src/explain/tests.rs
@@ -1,1 +1,254 @@
-// Tests added in Tasks 3 and 4.
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use crate::explain::ExplainAnalyzer;
+use crate::types::{
+    CapabilityDeclaration, CapabilityInvocation, CompositionSpec, GrammarCategoryKind,
+    MutationProfile, OutcomeDeclaration,
+};
+use crate::ExpressionEngine;
+
+fn test_registry() -> HashMap<String, CapabilityDeclaration> {
+    let mut reg = HashMap::new();
+    reg.insert(
+        "transform".to_owned(),
+        CapabilityDeclaration {
+            name: "transform".to_owned(),
+            grammar_category: GrammarCategoryKind::Transform,
+            description: "Pure data transformation".to_owned(),
+            config_schema: json!({
+                "type": "object",
+                "required": ["output", "filter"],
+                "properties": {
+                    "output": {"type": "object"},
+                    "filter": {"type": "string"}
+                }
+            }),
+            mutation_profile: MutationProfile::NonMutating,
+            tags: vec![],
+            version: "1.0.0".to_owned(),
+        },
+    );
+    reg.insert(
+        "persist".to_owned(),
+        CapabilityDeclaration {
+            name: "persist".to_owned(),
+            grammar_category: GrammarCategoryKind::Persist,
+            description: "Write data to a resource".to_owned(),
+            config_schema: json!({
+                "type": "object",
+                "required": ["resource", "data"],
+                "properties": {
+                    "resource": {"type": "object"},
+                    "data": {"type": "object"}
+                }
+            }),
+            mutation_profile: MutationProfile::Mutating {
+                supports_idempotency_key: true,
+            },
+            tags: vec![],
+            version: "1.0.0".to_owned(),
+        },
+    );
+    reg.insert(
+        "assert".to_owned(),
+        CapabilityDeclaration {
+            name: "assert".to_owned(),
+            grammar_category: GrammarCategoryKind::Assert,
+            description: "Boolean assertion gate".to_owned(),
+            config_schema: json!({
+                "type": "object",
+                "required": ["filter"],
+                "properties": {
+                    "filter": {"type": "string"},
+                    "error": {"type": "string"}
+                }
+            }),
+            mutation_profile: MutationProfile::NonMutating,
+            tags: vec![],
+            version: "1.0.0".to_owned(),
+        },
+    );
+    reg
+}
+
+fn test_engine() -> ExpressionEngine {
+    ExpressionEngine::with_defaults()
+}
+
+#[test]
+fn analyze_single_transform() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test outcome".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "transform".to_owned(),
+            config: json!({
+                "output": {"type": "object", "properties": {"result": {"type": "string"}}},
+                "filter": "{result: .context.name}"
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert!(!trace.simulated);
+    assert_eq!(trace.name, Some("test".to_owned()));
+    assert_eq!(trace.invocations.len(), 1);
+
+    let inv = &trace.invocations[0];
+    assert_eq!(inv.index, 0);
+    assert_eq!(inv.capability, "transform");
+    assert_eq!(inv.category, GrammarCategoryKind::Transform);
+    assert!(!inv.checkpoint);
+    assert!(!inv.is_mutating);
+    assert!(!inv.envelope_available.has_prev);
+    assert!(inv.envelope_available.prev_source.is_none());
+    assert!(inv.output_schema.is_some());
+    assert!(inv.simulated_output.is_none());
+
+    assert_eq!(inv.expressions.len(), 1);
+    assert_eq!(inv.expressions[0].field_path, "config.filter");
+    assert!(inv.expressions[0]
+        .referenced_paths
+        .contains(&".context.name".to_owned()));
+}
+
+#[test]
+fn analyze_multi_invocation_chain() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("chain".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Chained".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object", "properties": {"x": {"type": "number"}}},
+                    "filter": "{x: .context.value}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object", "properties": {"doubled": {"type": "number"}}},
+                    "filter": "{doubled: (.prev.x * 2)}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert_eq!(trace.invocations.len(), 2);
+
+    assert!(!trace.invocations[0].envelope_available.has_prev);
+
+    let inv1 = &trace.invocations[1];
+    assert!(inv1.envelope_available.has_prev);
+    assert!(inv1
+        .envelope_available
+        .prev_source
+        .as_ref()
+        .unwrap()
+        .contains("invocation 0"));
+    assert!(inv1.envelope_available.prev_schema.is_some());
+    assert!(inv1.expressions[0]
+        .referenced_paths
+        .contains(&".prev.x".to_owned()));
+}
+
+#[test]
+fn analyze_checkpoint_and_mutating() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Persist test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": {"type": "postgres", "table": "orders"},
+                "data": {"expression": ".prev.payload"}
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    let inv = &trace.invocations[0];
+    assert!(inv.checkpoint);
+    assert!(inv.is_mutating);
+    assert_eq!(inv.expressions.len(), 1);
+    assert_eq!(inv.expressions[0].field_path, "config.data.expression");
+}
+
+#[test]
+fn analyze_empty_composition() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Empty".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert!(trace.invocations.is_empty());
+    assert!(trace
+        .validation
+        .iter()
+        .any(|f| f.code == "EMPTY_COMPOSITION"));
+}
+
+#[test]
+fn analyze_missing_capability() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Bad ref".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "nonexistent".to_owned(),
+            config: json!({}),
+            checkpoint: false,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert_eq!(trace.invocations.len(), 1);
+    assert!(trace
+        .validation
+        .iter()
+        .any(|f| f.code == "MISSING_CAPABILITY"));
+}

--- a/crates/tasker-grammar/src/explain/tests.rs
+++ b/crates/tasker-grammar/src/explain/tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::json;
 
+use crate::explain::types::SimulationInput;
 use crate::explain::ExplainAnalyzer;
 use crate::types::{
     CapabilityDeclaration, CapabilityInvocation, CompositionSpec, GrammarCategoryKind,
@@ -251,4 +252,233 @@ fn analyze_missing_capability() {
         .validation
         .iter()
         .any(|f| f.code == "MISSING_CAPABILITY"));
+}
+
+#[test]
+fn analyze_with_simulation_threads_data() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("sim_test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Simulation".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{doubled: (.context.value * 2)}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{result: (.prev.doubled + 1)}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let input = SimulationInput {
+        context: json!({"value": 21}),
+        deps: json!({}),
+        step: json!({"name": "test_step"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    assert!(trace.simulated);
+
+    let inv0 = &trace.invocations[0];
+    assert_eq!(inv0.simulated_output, Some(json!({"doubled": 42})));
+    assert_eq!(
+        inv0.expressions[0].simulated_result,
+        Some(json!({"doubled": 42}))
+    );
+
+    let inv1 = &trace.invocations[1];
+    assert_eq!(inv1.simulated_output, Some(json!({"result": 43})));
+}
+
+#[test]
+fn analyze_with_simulation_mock_outputs() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Mock test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "persist".to_owned(),
+                config: json!({
+                    "resource": {"type": "postgres", "table": "orders"},
+                    "data": {"expression": ".context.order"}
+                }),
+                checkpoint: true,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{id: .prev.inserted_id}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let mut mock_outputs = HashMap::new();
+    mock_outputs.insert(0, json!({"inserted_id": 42}));
+
+    let input = SimulationInput {
+        context: json!({"order": {"item": "widget"}}),
+        deps: json!({}),
+        step: json!({"name": "persist_step"}),
+        mock_outputs,
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+
+    let inv0 = &trace.invocations[0];
+    assert!(inv0.mock_output_used);
+    assert_eq!(inv0.simulated_output, Some(json!({"inserted_id": 42})));
+
+    let inv1 = &trace.invocations[1];
+    assert!(!inv1.mock_output_used);
+    assert_eq!(inv1.simulated_output, Some(json!({"id": 42})));
+}
+
+#[test]
+fn analyze_with_simulation_missing_mock() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "No mock".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": {"type": "postgres", "table": "orders"},
+                "data": {"expression": ".context.order"}
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let input = SimulationInput {
+        context: json!({"order": {"item": "widget"}}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    let inv = &trace.invocations[0];
+    assert!(!inv.mock_output_used);
+    assert!(trace.validation.iter().any(|f| f.message.contains("mock")));
+}
+
+#[test]
+fn analyze_with_simulation_assert_passthrough() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Assert passthrough".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{x: .context.value}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "assert".to_owned(),
+                config: json!({"filter": "(.prev.x > 0)", "error": "must be positive"}),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{result: .prev.x}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let input = SimulationInput {
+        context: json!({"value": 5}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+
+    let assert_inv = &trace.invocations[1];
+    assert_eq!(assert_inv.simulated_output, Some(json!({"x": 5})));
+
+    let final_inv = &trace.invocations[2];
+    assert_eq!(final_inv.simulated_output, Some(json!({"result": 5})));
+}
+
+#[test]
+fn analyze_with_simulation_expression_failure() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Eval failure".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "transform".to_owned(),
+            config: json!({
+                "output": {"type": "object"},
+                "filter": ".prev.missing_field | .nested"
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let input = SimulationInput {
+        context: json!({}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    assert!(trace.simulated);
+    // Trace should be produced without panic
+    assert_eq!(trace.invocations.len(), 1);
 }

--- a/crates/tasker-grammar/src/explain/tests.rs
+++ b/crates/tasker-grammar/src/explain/tests.rs
@@ -1,0 +1,1 @@
+// Tests added in Tasks 3 and 4.

--- a/crates/tasker-grammar/src/explain/types.rs
+++ b/crates/tasker-grammar/src/explain/types.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::types::{GrammarCategoryKind, ValidationFinding};
+
+/// Complete trace of data flow through a composition.
+#[derive(Debug, Clone)]
+pub struct ExplanationTrace {
+    /// Composition name (if declared).
+    pub name: Option<String>,
+    /// Declared outcome description and output schema.
+    pub outcome: OutcomeSummary,
+    /// Per-invocation trace entries, in execution order.
+    pub invocations: Vec<InvocationTrace>,
+    /// Validation findings (errors/warnings) from the underlying validator.
+    pub validation: Vec<ValidationFinding>,
+    /// Whether simulation was performed (sample data provided).
+    pub simulated: bool,
+}
+
+/// Summary of the declared outcome.
+#[derive(Debug, Clone)]
+pub struct OutcomeSummary {
+    /// Human-readable description of what the composition achieves.
+    pub description: String,
+    /// JSON Schema for the composition's output.
+    pub output_schema: Value,
+}
+
+/// Trace for a single capability invocation.
+#[derive(Debug, Clone)]
+pub struct InvocationTrace {
+    /// Position in the invocation chain (0-based).
+    pub index: usize,
+    /// Capability name.
+    pub capability: String,
+    /// Grammar category.
+    pub category: GrammarCategoryKind,
+    /// Whether this is a checkpoint boundary.
+    pub checkpoint: bool,
+    /// Whether this capability is mutating.
+    pub is_mutating: bool,
+    /// Envelope fields available at this invocation.
+    pub envelope_available: EnvelopeSnapshot,
+    /// Jaq expressions found in config and which envelope paths they reference.
+    pub expressions: Vec<ExpressionReference>,
+    /// Declared output schema (if any — transforms declare this).
+    pub output_schema: Option<Value>,
+    /// Simulated output value (when sample data provided).
+    pub simulated_output: Option<Value>,
+    /// For side-effecting capabilities: whether a mock output was provided.
+    pub mock_output_used: bool,
+}
+
+/// What's available in the envelope at a given point in the chain.
+#[derive(Debug, Clone)]
+pub struct EnvelopeSnapshot {
+    /// Always true — task-level input.
+    pub context: bool,
+    /// Always true — dependency step results.
+    pub deps: bool,
+    /// Always true — step metadata.
+    pub step: bool,
+    /// Whether .prev is non-null at this point.
+    pub has_prev: bool,
+    /// Description of what .prev contains (e.g., "output of invocation 0 (transform)").
+    pub prev_source: Option<String>,
+    /// Schema of .prev if known (from prior invocation's output schema).
+    pub prev_schema: Option<Value>,
+}
+
+/// A jaq expression found in an invocation's config.
+#[derive(Debug, Clone)]
+pub struct ExpressionReference {
+    /// Config field path (e.g., "filter", "data.expression").
+    pub field_path: String,
+    /// The raw expression string.
+    pub expression: String,
+    /// Envelope paths referenced (e.g., [".context.order_id", ".prev.total"]).
+    pub referenced_paths: Vec<String>,
+    /// Simulated result value (when sample data provided).
+    pub simulated_result: Option<Value>,
+}
+
+/// Sample data for simulated evaluation.
+#[derive(Debug, Clone)]
+pub struct SimulationInput {
+    /// Sample task-level input — populates .context
+    pub context: Value,
+    /// Sample dependency results — populates .deps
+    pub deps: Value,
+    /// Sample step metadata — populates .step
+    pub step: Value,
+    /// Mock outputs for side-effecting invocations, keyed by invocation index.
+    /// Used as .prev for the next invocation when the capability can't be
+    /// evaluated purely (persist, acquire, emit).
+    pub mock_outputs: HashMap<usize, Value>,
+}

--- a/crates/tasker-grammar/src/expression/mod.rs
+++ b/crates/tasker-grammar/src/expression/mod.rs
@@ -87,6 +87,33 @@ impl ExpressionEngine {
         self.compile_filter(filter).map(|_| ())
     }
 
+    /// Extract envelope field references from a jaq expression.
+    ///
+    /// Scans the expression string for path patterns rooted at the four envelope
+    /// fields: `.context`, `.deps`, `.prev`, `.step`. Returns deduplicated paths
+    /// sorted alphabetically.
+    ///
+    /// Uses regex-based extraction (jaq-core compiles to an opaque `Filter` type
+    /// with no walkable AST). Handles common patterns: `.context.field`,
+    /// `.deps.step_name.field`, `.prev.nested.path`. Dynamic patterns like
+    /// `.context | keys` are captured as the root reference (`.context`).
+    pub fn extract_references(&self, expression: &str) -> Result<Vec<String>, ExpressionError> {
+        // First validate syntax so we don't extract from invalid expressions
+        self.validate_syntax(expression)?;
+
+        use std::collections::BTreeSet;
+
+        let pattern = regex::Regex::new(r"\.(context|deps|prev|step)(\.[a-zA-Z_][a-zA-Z0-9_]*)*")
+            .expect("static regex");
+
+        let refs: BTreeSet<String> = pattern
+            .find_iter(expression)
+            .map(|m| m.as_str().to_owned())
+            .collect();
+
+        Ok(refs.into_iter().collect())
+    }
+
     /// Evaluate a jq filter against an input JSON value.
     ///
     /// Returns the first output value from the filter. If the filter produces

--- a/crates/tasker-grammar/src/expression/tests.rs
+++ b/crates/tasker-grammar/src/expression/tests.rs
@@ -824,3 +824,66 @@ fn evaluate_multi_default_limit_handles_reasonable_output() {
     let result = engine().evaluate_multi("range(50)", &json!(null)).unwrap();
     assert_eq!(result.len(), 50);
 }
+
+// ─── Reference Extraction ────────────────────────────────────────────────
+
+#[test]
+fn extract_references_simple_context() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".context.order_id").unwrap();
+    assert_eq!(refs, vec![".context.order_id"]);
+}
+
+#[test]
+fn extract_references_prev_field() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".prev.total").unwrap();
+    assert_eq!(refs, vec![".prev.total"]);
+}
+
+#[test]
+fn extract_references_deps_nested() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".deps.step_a.result").unwrap();
+    assert_eq!(refs, vec![".deps.step_a.result"]);
+}
+
+#[test]
+fn extract_references_step_metadata() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".step.name").unwrap();
+    assert_eq!(refs, vec![".step.name"]);
+}
+
+#[test]
+fn extract_references_multiple_paths() {
+    let engine = ExpressionEngine::with_defaults();
+    let mut refs = engine
+        .extract_references("{total: .prev.amount, id: .context.order_id}")
+        .unwrap();
+    refs.sort();
+    assert_eq!(refs, vec![".context.order_id", ".prev.amount"]);
+}
+
+#[test]
+fn extract_references_root_only() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".context | keys").unwrap();
+    assert_eq!(refs, vec![".context"]);
+}
+
+#[test]
+fn extract_references_no_envelope_paths() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references("42").unwrap();
+    assert!(refs.is_empty());
+}
+
+#[test]
+fn extract_references_deduplicates() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine
+        .extract_references("{a: .prev.x, b: .prev.x}")
+        .unwrap();
+    assert_eq!(refs, vec![".prev.x"]);
+}

--- a/crates/tasker-grammar/src/lib.rs
+++ b/crates/tasker-grammar/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod capabilities;
 pub mod executor;
+pub mod explain;
 pub mod expression;
 pub mod fixtures;
 pub mod operations;
@@ -32,6 +33,10 @@ pub mod types;
 pub mod validation;
 pub mod vocabulary;
 
+pub use explain::{
+    EnvelopeSnapshot, ExplainAnalyzer, ExplanationTrace, ExpressionReference, InvocationTrace,
+    OutcomeSummary, SimulationInput,
+};
 pub use expression::{ExpressionEngine, ExpressionEngineConfig, ExpressionError};
 pub use operations::{
     AcquirableResource, AcquireConstraints, AcquireResult, CapturedEmit, CapturedPersist,

--- a/crates/tasker-mcp/src/server.rs
+++ b/crates/tasker-mcp/src/server.rs
@@ -1045,11 +1045,11 @@ base_url = "http://localhost:8080"
         let tools = server.tool_router.list_all();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
 
-        // Should have only Tier 1 tools (13), no connection_status (offline)
+        // Should have only Tier 1 tools (14), no connection_status (offline)
         assert_eq!(
             names.len(),
-            13,
-            "Expected 13 Tier 1 tools, got: {:?}",
+            14,
+            "Expected 14 Tier 1 tools, got: {:?}",
             names
         );
         assert!(names.contains(&"template_validate"));
@@ -1075,11 +1075,11 @@ base_url = "http://localhost:8080"
         let tools = server.tool_router.list_all();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
 
-        // 13 Tier 1 + 1 connection_status + 16 Tier 2 = 30
+        // 14 Tier 1 + 1 connection_status + 16 Tier 2 = 31
         assert_eq!(
             names.len(),
-            30,
-            "Expected 30 tools (T1+profile+T2), got: {:?}",
+            31,
+            "Expected 31 tools (T1+profile+T2), got: {:?}",
             names
         );
         assert!(names.contains(&"template_validate"));
@@ -1097,8 +1097,8 @@ base_url = "http://localhost:8080"
         let server = TaskerMcpServer::with_profile_manager(pm, false, None);
 
         let tools = server.tool_router.list_all();
-        // 13 T1 + 1 profile + 16 T2 + 6 T3 = 36
-        assert_eq!(tools.len(), 36, "Expected all 36 tools");
+        // 14 T1 + 1 profile + 16 T2 + 6 T3 = 37
+        assert_eq!(tools.len(), 37, "Expected all 37 tools");
     }
 
     #[tokio::test]
@@ -1210,8 +1210,8 @@ base_url = "http://localhost:8080"
         // Should have T1 + profile + T2, no T3
         assert_eq!(
             names.len(),
-            30,
-            "Expected 30 tools from profile config, got: {:?}",
+            31,
+            "Expected 31 tools from profile config, got: {:?}",
             names
         );
         assert!(!names.contains(&"task_submit"));

--- a/crates/tasker-mcp/src/server.rs
+++ b/crates/tasker-mcp/src/server.rs
@@ -17,6 +17,7 @@
 //! - `capability_inspect` — Inspect capability config schema and metadata
 //! - `vocabulary_document` — Generate complete vocabulary documentation
 //! - `composition_validate` — Validate a standalone composition spec
+//! - `composition_explain` — Analyze and explain data flow through a composition spec
 //!
 //! **Profile Management (when profiles configured)**
 //! - `connection_status` — Show profile health and available capabilities
@@ -455,6 +456,18 @@ impl TaskerMcpServer {
         Parameters(params): Parameters<CompositionValidateParams>,
     ) -> String {
         developer::composition_validate(params)
+    }
+
+    /// Explain data flow through a composition spec.
+    #[tool(
+        name = "composition_explain",
+        description = "Analyze and explain data flow through a CompositionSpec. Shows how data threads through invocations via the envelope (.context, .deps, .prev, .step), which jaq expressions reference which fields, checkpoint placement, and output schemas. Optionally evaluates expressions against sample data for simulated execution. Works offline."
+    )]
+    pub async fn composition_explain(
+        &self,
+        Parameters(params): Parameters<CompositionExplainParams>,
+    ) -> String {
+        developer::composition_explain(params)
     }
 
     // ── Profile Management ──

--- a/crates/tasker-mcp/src/tools/developer.rs
+++ b/crates/tasker-mcp/src/tools/developer.rs
@@ -15,11 +15,11 @@ use tasker_sdk::template_parser::parse_template_str;
 
 use super::helpers::{error_json, topological_sort};
 use super::params::{
-    CapabilityInspectParams, CapabilitySearchParams, CompositionValidateParams, FieldDetail,
-    HandlerGenerateParams, HandlerGenerateResponse, SchemaCompareParams, SchemaDiffParams,
-    SchemaInspectParams, SchemaInspectResponse, StepInspection, StepSchemaDetail,
-    TemplateGenerateParams, TemplateInspectParams, TemplateInspectResponse, TemplateValidateParams,
-    TemplateVisualizeParams,
+    CapabilityInspectParams, CapabilitySearchParams, CompositionExplainParams,
+    CompositionValidateParams, FieldDetail, HandlerGenerateParams, HandlerGenerateResponse,
+    SchemaCompareParams, SchemaDiffParams, SchemaInspectParams, SchemaInspectResponse,
+    StepInspection, StepSchemaDetail, TemplateGenerateParams, TemplateInspectParams,
+    TemplateInspectResponse, TemplateValidateParams, TemplateVisualizeParams,
 };
 
 pub fn template_validate(params: TemplateValidateParams) -> String {
@@ -364,6 +364,57 @@ pub fn vocabulary_document() -> String {
 pub fn composition_validate(params: CompositionValidateParams) -> String {
     let report = grammar_query::validate_composition_yaml(&params.composition_yaml);
     serde_json::to_string_pretty(&report)
+        .unwrap_or_else(|e| error_json("serialization_error", &e.to_string()))
+}
+
+pub fn composition_explain(params: CompositionExplainParams) -> String {
+    use tasker_sdk::grammar_query::SimulationInput;
+
+    let simulation = if params.sample_context.is_some()
+        || params.sample_deps.is_some()
+        || params.sample_step.is_some()
+        || params.mock_outputs.is_some()
+    {
+        let context = params
+            .sample_context
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let deps = params
+            .sample_deps
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let step = params
+            .sample_step
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let mock_outputs: HashMap<usize, serde_json::Value> = params
+            .mock_outputs
+            .as_deref()
+            .and_then(|s| {
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(s).ok()
+            })
+            .map(|map| {
+                map.into_iter()
+                    .filter_map(|(k, v)| k.parse::<usize>().ok().map(|idx| (idx, v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Some(SimulationInput {
+            context,
+            deps,
+            step,
+            mock_outputs,
+        })
+    } else {
+        None
+    };
+
+    let explanation = grammar_query::explain_composition(&params.composition_yaml, simulation);
+    serde_json::to_string_pretty(&explanation)
         .unwrap_or_else(|e| error_json("serialization_error", &e.to_string()))
 }
 

--- a/crates/tasker-mcp/src/tools/params.rs
+++ b/crates/tasker-mcp/src/tools/params.rs
@@ -794,3 +794,43 @@ pub struct CompositionValidateParams {
     )]
     pub composition_yaml: String,
 }
+
+// ── composition_explain ──
+
+/// Parameters for the `composition_explain` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CompositionExplainParams {
+    /// Composition spec as YAML or JSON string.
+    #[schemars(
+        description = "Composition spec as YAML or JSON string. Must include name, outcome (with output_schema), and invocations array."
+    )]
+    pub composition_yaml: String,
+
+    /// Optional sample context data as JSON string for simulated evaluation.
+    #[schemars(
+        description = "Sample task-level input data as JSON string. Populates .context in the envelope for simulated evaluation."
+    )]
+    #[serde(default)]
+    pub sample_context: Option<String>,
+
+    /// Optional sample dependency results as JSON string.
+    #[schemars(
+        description = "Sample dependency step results as JSON string. Populates .deps in the envelope."
+    )]
+    #[serde(default)]
+    pub sample_deps: Option<String>,
+
+    /// Optional sample step metadata as JSON string.
+    #[schemars(
+        description = "Sample step metadata as JSON string. Populates .step in the envelope."
+    )]
+    #[serde(default)]
+    pub sample_step: Option<String>,
+
+    /// Mock outputs for side-effecting invocations as JSON string.
+    #[schemars(
+        description = "Mock outputs for side-effecting invocations as JSON object keyed by invocation index (e.g. {\"0\": {\"id\": 123}}). Used as .prev for subsequent invocations."
+    )]
+    #[serde(default)]
+    pub mock_outputs: Option<String>,
+}

--- a/crates/tasker-mcp/tests/mcp_protocol_test.rs
+++ b/crates/tasker-mcp/tests/mcp_protocol_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses the real `TaskerMcpServer` from the library target to verify protocol
 //! round-trips: tool discovery via `list_tools` and tool invocation via `call_tool`
-//! for all 36 tools (13 Tier 1/profile + 16 Tier 2 connected + 6 Tier 3 write).
+//! for all 37 tools (14 Tier 1/profile + 16 Tier 2 connected + 6 Tier 3 write).
 
 use rmcp::model::{CallToolRequestParams, ClientInfo};
 use rmcp::service::{RoleClient, RunningService};
@@ -124,6 +124,7 @@ async fn test_list_tools_offline_returns_tier1() -> anyhow::Result<()> {
         vec![
             "capability_inspect",
             "capability_search",
+            "composition_explain",
             "composition_validate",
             "grammar_list",
             "handler_generate",
@@ -137,7 +138,7 @@ async fn test_list_tools_offline_returns_tier1() -> anyhow::Result<()> {
             "vocabulary_document",
         ]
     );
-    assert_eq!(names.len(), 13, "Expected 13 Tier 1 tools in offline mode");
+    assert_eq!(names.len(), 14, "Expected 14 Tier 1 tools in offline mode");
 
     client.cancel().await?;
     server_handle.await??;
@@ -159,6 +160,7 @@ async fn test_list_tools_connected_returns_all() -> anyhow::Result<()> {
             "analytics_performance",
             "capability_inspect",
             "capability_search",
+            "composition_explain",
             "composition_validate",
             "connection_status",
             "dlq_inspect",
@@ -195,8 +197,8 @@ async fn test_list_tools_connected_returns_all() -> anyhow::Result<()> {
     );
     assert_eq!(
         names.len(),
-        36,
-        "Expected 36 tools: 13 Tier 1 + 1 profile + 16 Tier 2 connected + 6 Tier 3 write"
+        37,
+        "Expected 37 tools: 14 Tier 1 + 1 profile + 16 Tier 2 connected + 6 Tier 3 write"
     );
 
     client.cancel().await?;
@@ -212,8 +214,8 @@ async fn test_list_tools_tier_filtered() -> anyhow::Result<()> {
     let tools = client.list_tools(None).await?;
     let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
 
-    // 13 T1 + 1 connection_status + 16 T2 = 30
-    assert_eq!(names.len(), 30, "Expected 30 tools (T1+profile+T2)");
+    // 14 T1 + 1 connection_status + 16 T2 = 31
+    assert_eq!(names.len(), 31, "Expected 31 tools (T1+profile+T2)");
     assert!(names.contains(&"template_validate"));
     assert!(names.contains(&"task_list"));
     assert!(names.contains(&"connection_status"));

--- a/crates/tasker-sdk/src/grammar_query.rs
+++ b/crates/tasker-sdk/src/grammar_query.rs
@@ -94,6 +94,87 @@ pub struct CompositionValidationReport {
     pub summary: String,
 }
 
+/// Summary of the declared outcome for a composition explanation.
+#[derive(Debug, Serialize)]
+pub struct OutcomeInfo {
+    /// Human-readable description of what the composition achieves.
+    pub description: String,
+    /// JSON Schema for the composition's output.
+    pub output_schema: Value,
+}
+
+/// Snapshot of what envelope fields are available at an invocation point.
+#[derive(Debug, Serialize)]
+pub struct EnvelopeSnapshotInfo {
+    /// Always true — task-level input.
+    pub context: bool,
+    /// Always true — dependency step results.
+    pub deps: bool,
+    /// Always true — step metadata.
+    pub step: bool,
+    /// Whether .prev is non-null at this point.
+    pub has_prev: bool,
+    /// Description of what .prev contains.
+    pub prev_source: Option<String>,
+    /// Schema of .prev if known (from prior invocation's output schema).
+    pub prev_schema: Option<Value>,
+}
+
+/// A jaq expression found in an invocation's config.
+#[derive(Debug, Serialize)]
+pub struct ExpressionReferenceInfo {
+    /// Config field path (e.g., "filter", "data.expression").
+    pub field_path: String,
+    /// The raw expression string.
+    pub expression: String,
+    /// Envelope paths referenced (e.g., [".context.order_id", ".prev.total"]).
+    pub referenced_paths: Vec<String>,
+    /// Simulated result value (when sample data provided).
+    pub simulated_result: Option<Value>,
+}
+
+/// Trace for a single capability invocation within a composition explanation.
+#[derive(Debug, Serialize)]
+pub struct InvocationExplanation {
+    /// Position in the invocation chain (0-based).
+    pub index: usize,
+    /// Capability name.
+    pub capability: String,
+    /// Grammar category (as string, e.g., "Transform", "Persist").
+    pub category: String,
+    /// Whether this is a checkpoint boundary.
+    pub checkpoint: bool,
+    /// Whether this capability mutates external state.
+    pub is_mutating: bool,
+    /// Envelope fields available at this invocation.
+    pub envelope_available: EnvelopeSnapshotInfo,
+    /// Jaq expressions found in config and which envelope paths they reference.
+    pub expressions: Vec<ExpressionReferenceInfo>,
+    /// Declared output schema (if any — transforms declare this).
+    pub output_schema: Option<Value>,
+    /// Simulated output value (when sample data provided).
+    pub simulated_output: Option<Value>,
+    /// For side-effecting capabilities: whether a mock output was provided.
+    pub mock_output_used: bool,
+}
+
+/// Result of explaining data flow through a composition.
+#[derive(Debug, Serialize)]
+pub struct CompositionExplanation {
+    /// Composition name (if declared).
+    pub name: Option<String>,
+    /// Declared outcome description and output schema.
+    pub outcome: OutcomeInfo,
+    /// Per-invocation trace entries, in execution order.
+    pub invocations: Vec<InvocationExplanation>,
+    /// Validation findings (errors/warnings) from the underlying validator.
+    pub findings: Vec<CompositionFinding>,
+    /// Whether simulation was performed (sample data provided).
+    pub simulated: bool,
+    /// Human-readable summary of the composition.
+    pub summary: String,
+}
+
 // ---------------------------------------------------------------------------
 // Constants and helpers
 // ---------------------------------------------------------------------------
@@ -284,6 +365,131 @@ pub fn validate_composition_yaml(yaml_str: &str) -> CompositionValidationReport 
     }
 }
 
+/// Explain data flow through a composition, optionally with simulation.
+///
+/// Parses the input (YAML first, then JSON), constructs an `ExplainAnalyzer`
+/// with the standard capability registry, and returns a structured trace.
+/// If simulation input is provided, expressions are evaluated against sample data.
+pub fn explain_composition(
+    yaml_str: &str,
+    simulation: Option<tasker_grammar::SimulationInput>,
+) -> CompositionExplanation {
+    use tasker_grammar::{CompositionSpec, ExplainAnalyzer, ExpressionEngine, Severity};
+
+    // Try YAML first, then JSON
+    let spec: CompositionSpec = match serde_yaml::from_str(yaml_str) {
+        Ok(s) => s,
+        Err(yaml_err) => match serde_json::from_str(yaml_str) {
+            Ok(s) => s,
+            Err(_) => {
+                return CompositionExplanation {
+                    name: None,
+                    outcome: OutcomeInfo {
+                        description: String::new(),
+                        output_schema: Value::Object(Default::default()),
+                    },
+                    invocations: vec![],
+                    findings: vec![CompositionFinding {
+                        severity: "error".to_owned(),
+                        code: "PARSE_ERROR".to_owned(),
+                        message: format!("Failed to parse composition: {yaml_err}"),
+                        invocation_index: None,
+                        field_path: None,
+                    }],
+                    simulated: false,
+                    summary: "Composition could not be parsed".to_owned(),
+                };
+            }
+        },
+    };
+
+    let registry = standard_capability_registry();
+    let engine = ExpressionEngine::with_defaults();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let trace = if let Some(sim) = simulation {
+        analyzer.analyze_with_simulation(&spec, &sim)
+    } else {
+        analyzer.analyze(&spec)
+    };
+
+    // Map validation findings
+    let findings: Vec<CompositionFinding> = trace
+        .validation
+        .iter()
+        .map(|f| CompositionFinding {
+            severity: match f.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "info",
+            }
+            .to_owned(),
+            code: f.code.clone(),
+            message: f.message.clone(),
+            invocation_index: f.invocation_index,
+            field_path: f.field_path.clone(),
+        })
+        .collect();
+
+    // Map invocations
+    let invocations: Vec<InvocationExplanation> = trace
+        .invocations
+        .into_iter()
+        .map(|inv| InvocationExplanation {
+            index: inv.index,
+            capability: inv.capability,
+            category: inv.category.to_string(),
+            checkpoint: inv.checkpoint,
+            is_mutating: inv.is_mutating,
+            envelope_available: EnvelopeSnapshotInfo {
+                context: inv.envelope_available.context,
+                deps: inv.envelope_available.deps,
+                step: inv.envelope_available.step,
+                has_prev: inv.envelope_available.has_prev,
+                prev_source: inv.envelope_available.prev_source,
+                prev_schema: inv.envelope_available.prev_schema,
+            },
+            expressions: inv
+                .expressions
+                .into_iter()
+                .map(|e| ExpressionReferenceInfo {
+                    field_path: e.field_path,
+                    expression: e.expression,
+                    referenced_paths: e.referenced_paths,
+                    simulated_result: e.simulated_result,
+                })
+                .collect(),
+            output_schema: inv.output_schema,
+            simulated_output: inv.simulated_output,
+            mock_output_used: inv.mock_output_used,
+        })
+        .collect();
+
+    // Build summary
+    let checkpoint_count = invocations.iter().filter(|i| i.checkpoint).count();
+    let summary = if checkpoint_count > 0 {
+        format!(
+            "Composition has {} invocation(s), {} checkpoint(s)",
+            invocations.len(),
+            checkpoint_count
+        )
+    } else {
+        format!("Composition has {} invocation(s)", invocations.len())
+    };
+
+    CompositionExplanation {
+        name: trace.name,
+        outcome: OutcomeInfo {
+            description: trace.outcome.description,
+            output_schema: trace.outcome.output_schema,
+        },
+        invocations,
+        findings,
+        simulated: trace.simulated,
+        summary,
+    }
+}
+
 /// Generate complete vocabulary documentation covering all categories and capabilities.
 pub fn document_vocabulary() -> VocabularyDocumentation {
     let categories = list_grammar_categories();
@@ -416,6 +622,67 @@ invocations:
         let report = validate_composition_yaml("not: valid: yaml: [[[");
         assert!(!report.valid);
         assert_eq!(report.findings[0].code, "PARSE_ERROR");
+    }
+
+    #[test]
+    fn explain_composition_static() {
+        let yaml = r#"
+name: test
+outcome:
+  description: Test outcome
+  output_schema: {}
+invocations:
+  - capability: transform
+    config:
+      output:
+        type: object
+        properties:
+          x:
+            type: string
+        required: [x]
+      filter: "{x: .context.name}"
+    checkpoint: false
+"#;
+        let explanation = explain_composition(yaml, None);
+        assert!(!explanation.simulated);
+        assert_eq!(explanation.invocations.len(), 1);
+        assert_eq!(explanation.invocations[0].capability, "transform");
+        assert_eq!(explanation.invocations[0].category, "Transform");
+        assert!(!explanation.invocations[0].expressions.is_empty());
+    }
+
+    #[test]
+    fn explain_composition_with_simulation() {
+        let yaml = r#"
+name: sim
+outcome:
+  description: Simulation
+  output_schema: {}
+invocations:
+  - capability: transform
+    config:
+      output: {type: object}
+      filter: "{doubled: (.context.value * 2)}"
+    checkpoint: false
+"#;
+        let sim = tasker_grammar::SimulationInput {
+            context: serde_json::json!({"value": 21}),
+            deps: serde_json::json!({}),
+            step: serde_json::json!({"name": "test"}),
+            mock_outputs: std::collections::HashMap::new(),
+        };
+        let explanation = explain_composition(yaml, Some(sim));
+        assert!(explanation.simulated);
+        assert_eq!(
+            explanation.invocations[0].simulated_output,
+            Some(serde_json::json!({"doubled": 42}))
+        );
+    }
+
+    #[test]
+    fn explain_composition_invalid_yaml() {
+        let explanation = explain_composition("not: valid: yaml: [[[", None);
+        assert!(explanation.findings.iter().any(|f| f.code == "PARSE_ERROR"));
     }
 
     #[test]

--- a/crates/tasker-sdk/src/grammar_query.rs
+++ b/crates/tasker-sdk/src/grammar_query.rs
@@ -8,6 +8,10 @@ use serde::Serialize;
 use serde_json::Value;
 use tasker_grammar::{standard_capability_registry, GrammarCategoryKind, MutationProfile};
 
+// Re-export SimulationInput so callers (tasker-mcp, tasker-ctl) don't need
+// a direct dependency on tasker-grammar.
+pub use tasker_grammar::SimulationInput;
+
 // ---------------------------------------------------------------------------
 // Return type structs
 // ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-03-20-tas-344-composition-explain-trace.md
+++ b/docs/superpowers/plans/2026-03-20-tas-344-composition-explain-trace.md
@@ -1,0 +1,1431 @@
+# TAS-344: Composition Explain Trace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `composition_explain` tool that traces data flow through a composition, with optional simulated evaluation against user-provided sample data.
+
+**Architecture:** `ExplainAnalyzer` in `tasker-grammar` performs the core analysis (static trace + optional simulation). `tasker-sdk` wraps it as `explain_composition()`. `tasker-mcp` exposes it as a Tier 1 offline tool, `tasker-ctl` as a CLI subcommand. This mirrors the existing `CompositionValidator` → `validate_composition_yaml` → `composition_validate` pattern.
+
+**Tech Stack:** Rust, jaq-core (expression evaluation), serde_json, regex (expression reference extraction), tasker-grammar/tasker-sdk/tasker-mcp/tasker-ctl crates.
+
+**Spec:** `docs/superpowers/specs/2026-03-20-tas-344-composition-explain-trace-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `crates/tasker-grammar/src/explain/mod.rs` | Module root: re-exports types and analyzer |
+| `crates/tasker-grammar/src/explain/types.rs` | `ExplanationTrace`, `InvocationTrace`, `EnvelopeSnapshot`, `ExpressionReference`, `OutcomeSummary`, `SimulationInput` |
+| `crates/tasker-grammar/src/explain/analyzer.rs` | `ExplainAnalyzer` with `analyze()` and `analyze_with_simulation()` |
+| `crates/tasker-grammar/src/explain/tests.rs` | All analyzer + extract_references tests |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `crates/tasker-grammar/src/lib.rs` | Add `pub mod explain;` and re-export key types |
+| `crates/tasker-grammar/src/expression/mod.rs` | Add `extract_references()` method to `ExpressionEngine` |
+| `crates/tasker-grammar/src/expression/tests.rs` | Add `extract_references` unit tests |
+| `crates/tasker-sdk/src/grammar_query.rs` | Add `explain_composition()` function and `CompositionExplanation` type |
+| `crates/tasker-mcp/src/tools/params.rs` | Add `CompositionExplainParams` struct |
+| `crates/tasker-mcp/src/tools/developer.rs` | Add `composition_explain()` handler function |
+| `crates/tasker-mcp/src/server.rs` | Register `composition_explain` tool (line ~458) |
+| `crates/tasker-mcp/tests/mcp_protocol_test.rs` | Update tool count assertions (13→14, 36→37, 30→31) |
+| `crates/tasker-ctl/src/commands/grammar.rs` | Add `Explain` variant to `CompositionCommands` and handler |
+
+---
+
+## Task 1: Expression Reference Extraction
+
+Add `extract_references()` to `ExpressionEngine` — the foundation for the explain trace's expression path analysis.
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/expression/mod.rs`
+- Test: `crates/tasker-grammar/src/expression/tests.rs`
+
+- [ ] **Step 1: Write failing tests for `extract_references`**
+
+Add to `crates/tasker-grammar/src/expression/tests.rs`:
+
+```rust
+#[test]
+fn extract_references_simple_context() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".context.order_id").unwrap();
+    assert_eq!(refs, vec![".context.order_id"]);
+}
+
+#[test]
+fn extract_references_prev_field() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".prev.total").unwrap();
+    assert_eq!(refs, vec![".prev.total"]);
+}
+
+#[test]
+fn extract_references_deps_nested() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".deps.step_a.result").unwrap();
+    assert_eq!(refs, vec![".deps.step_a.result"]);
+}
+
+#[test]
+fn extract_references_step_metadata() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".step.name").unwrap();
+    assert_eq!(refs, vec![".step.name"]);
+}
+
+#[test]
+fn extract_references_multiple_paths() {
+    let engine = ExpressionEngine::with_defaults();
+    let mut refs = engine
+        .extract_references("{total: .prev.amount, id: .context.order_id}")
+        .unwrap();
+    refs.sort();
+    assert_eq!(refs, vec![".context.order_id", ".prev.amount"]);
+}
+
+#[test]
+fn extract_references_root_only() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references(".context | keys").unwrap();
+    assert_eq!(refs, vec![".context"]);
+}
+
+#[test]
+fn extract_references_no_envelope_paths() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine.extract_references("42").unwrap();
+    assert!(refs.is_empty());
+}
+
+#[test]
+fn extract_references_deduplicates() {
+    let engine = ExpressionEngine::with_defaults();
+    let refs = engine
+        .extract_references("{a: .prev.x, b: .prev.x}")
+        .unwrap();
+    assert_eq!(refs, vec![".prev.x"]);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(extract_references)'`
+Expected: FAIL — `extract_references` method not found.
+
+- [ ] **Step 3: Implement `extract_references`**
+
+Add to `crates/tasker-grammar/src/expression/mod.rs`, after the `validate_syntax` method (line 88):
+
+```rust
+/// Extract envelope field references from a jaq expression.
+///
+/// Scans the expression string for path patterns rooted at the four envelope
+/// fields: `.context`, `.deps`, `.prev`, `.step`. Returns deduplicated paths
+/// sorted alphabetically.
+///
+/// Uses regex-based extraction (jaq-core compiles to an opaque `Filter` type
+/// with no walkable AST). Handles common patterns: `.context.field`,
+/// `.deps.step_name.field`, `.prev.nested.path`. Dynamic patterns like
+/// `.context | keys` are captured as the root reference (`.context`).
+pub fn extract_references(&self, expression: &str) -> Result<Vec<String>, ExpressionError> {
+    // First validate syntax so we don't extract from invalid expressions
+    self.validate_syntax(expression)?;
+
+    use std::collections::BTreeSet;
+
+    let pattern = regex::Regex::new(r"\.(context|deps|prev|step)(\.[a-zA-Z_][a-zA-Z0-9_]*)*")
+        .expect("static regex");
+
+    let refs: BTreeSet<String> = pattern
+        .find_iter(expression)
+        .map(|m| m.as_str().to_owned())
+        .collect();
+
+    Ok(refs.into_iter().collect())
+}
+```
+
+Add `regex` dependency to `crates/tasker-grammar/Cargo.toml` under `[dependencies]`:
+```toml
+regex = { workspace = true }
+```
+(The workspace root already defines `regex = "1.12"`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(extract_references)'`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Run clippy on the grammar crate**
+
+Run: `cargo clippy --all-targets --all-features -p tasker-grammar`
+Expected: Zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-grammar/src/expression/mod.rs crates/tasker-grammar/src/expression/tests.rs crates/tasker-grammar/Cargo.toml
+git commit -m "feat(TAS-344): add extract_references to ExpressionEngine
+
+Regex-based extraction of envelope path references (.context, .deps,
+.prev, .step) from jaq expressions. Foundation for composition explain
+trace data flow analysis."
+```
+
+---
+
+## Task 2: Explain Module Types
+
+Define the core types for the explanation trace in `tasker-grammar`.
+
+**Files:**
+- Create: `crates/tasker-grammar/src/explain/mod.rs`
+- Create: `crates/tasker-grammar/src/explain/types.rs`
+- Modify: `crates/tasker-grammar/src/lib.rs`
+
+- [ ] **Step 1: Create the explain module root**
+
+Create `crates/tasker-grammar/src/explain/mod.rs`:
+
+```rust
+//! Composition explanation and data flow tracing.
+//!
+//! The [`ExplainAnalyzer`] produces an [`ExplanationTrace`] that visualizes how
+//! data flows through a composition's invocation chain. Two modes:
+//!
+//! - **Static analysis**: traces structure, envelope field availability, expression
+//!   references, output schemas, and checkpoint placement.
+//! - **Simulated evaluation**: when [`SimulationInput`] is provided, evaluates jaq
+//!   expressions against sample data and threads computed results through the chain.
+//!
+//! **Ticket**: TAS-344
+
+mod analyzer;
+mod types;
+
+pub use analyzer::ExplainAnalyzer;
+pub use types::{
+    EnvelopeSnapshot, ExplanationTrace, ExpressionReference, InvocationTrace, OutcomeSummary,
+    SimulationInput,
+};
+
+#[cfg(test)]
+mod tests;
+```
+
+- [ ] **Step 2: Create the types file**
+
+Create `crates/tasker-grammar/src/explain/types.rs`:
+
+```rust
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::types::{GrammarCategoryKind, ValidationFinding};
+
+/// Complete trace of data flow through a composition.
+#[derive(Debug, Clone)]
+pub struct ExplanationTrace {
+    /// Composition name (if declared).
+    pub name: Option<String>,
+    /// Declared outcome description and output schema.
+    pub outcome: OutcomeSummary,
+    /// Per-invocation trace entries, in execution order.
+    pub invocations: Vec<InvocationTrace>,
+    /// Validation findings (errors/warnings) from the underlying validator.
+    pub validation: Vec<ValidationFinding>,
+    /// Whether simulation was performed (sample data provided).
+    pub simulated: bool,
+}
+
+/// Summary of the declared outcome.
+#[derive(Debug, Clone)]
+pub struct OutcomeSummary {
+    /// Human-readable description of what the composition achieves.
+    pub description: String,
+    /// JSON Schema for the composition's output.
+    pub output_schema: Value,
+}
+
+/// Trace for a single capability invocation.
+#[derive(Debug, Clone)]
+pub struct InvocationTrace {
+    /// Position in the invocation chain (0-based).
+    pub index: usize,
+    /// Capability name.
+    pub capability: String,
+    /// Grammar category.
+    pub category: GrammarCategoryKind,
+    /// Whether this is a checkpoint boundary.
+    pub checkpoint: bool,
+    /// Whether this capability is mutating.
+    pub is_mutating: bool,
+    /// Envelope fields available at this invocation.
+    pub envelope_available: EnvelopeSnapshot,
+    /// Jaq expressions found in config and which envelope paths they reference.
+    pub expressions: Vec<ExpressionReference>,
+    /// Declared output schema (if any — transforms declare this).
+    pub output_schema: Option<Value>,
+    /// Simulated output value (when sample data provided).
+    pub simulated_output: Option<Value>,
+    /// For side-effecting capabilities: whether a mock output was provided.
+    pub mock_output_used: bool,
+}
+
+/// What's available in the envelope at a given point in the chain.
+#[derive(Debug, Clone)]
+pub struct EnvelopeSnapshot {
+    /// Always true — task-level input.
+    pub context: bool,
+    /// Always true — dependency step results.
+    pub deps: bool,
+    /// Always true — step metadata.
+    pub step: bool,
+    /// Whether .prev is non-null at this point.
+    pub has_prev: bool,
+    /// Description of what .prev contains (e.g., "output of invocation 0 (transform)").
+    pub prev_source: Option<String>,
+    /// Schema of .prev if known (from prior invocation's output schema).
+    pub prev_schema: Option<Value>,
+}
+
+/// A jaq expression found in an invocation's config.
+#[derive(Debug, Clone)]
+pub struct ExpressionReference {
+    /// Config field path (e.g., "filter", "data.expression").
+    pub field_path: String,
+    /// The raw expression string.
+    pub expression: String,
+    /// Envelope paths referenced (e.g., [".context.order_id", ".prev.total"]).
+    pub referenced_paths: Vec<String>,
+    /// Simulated result value (when sample data provided).
+    pub simulated_result: Option<Value>,
+}
+
+/// Sample data for simulated evaluation.
+#[derive(Debug, Clone)]
+pub struct SimulationInput {
+    /// Sample task-level input — populates .context
+    pub context: Value,
+    /// Sample dependency results — populates .deps
+    pub deps: Value,
+    /// Sample step metadata — populates .step
+    pub step: Value,
+    /// Mock outputs for side-effecting invocations, keyed by invocation index.
+    /// Used as .prev for the next invocation when the capability can't be
+    /// evaluated purely (persist, acquire, emit).
+    pub mock_outputs: HashMap<usize, Value>,
+}
+```
+
+- [ ] **Step 3: Register the module in lib.rs**
+
+In `crates/tasker-grammar/src/lib.rs`, add `pub mod explain;` after line 27 (`pub mod executor;`), and add re-exports after the existing re-export block (after line 53):
+
+```rust
+pub use explain::{
+    EnvelopeSnapshot, ExplainAnalyzer, ExplanationTrace, ExpressionReference, InvocationTrace,
+    OutcomeSummary, SimulationInput,
+};
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check --all-features -p tasker-grammar`
+Expected: Compiles (analyzer.rs and tests.rs will be empty stubs or `// TODO` for now — create minimal files so the module compiles).
+
+Create stub `crates/tasker-grammar/src/explain/analyzer.rs`:
+```rust
+use crate::explain::types::{ExplanationTrace, SimulationInput};
+use crate::types::CompositionSpec;
+use crate::validation::CapabilityRegistry;
+use crate::ExpressionEngine;
+
+/// Analyzes a CompositionSpec to produce a data flow trace.
+pub struct ExplainAnalyzer<'a> {
+    registry: &'a dyn CapabilityRegistry,
+    expression_engine: &'a ExpressionEngine,
+}
+
+impl std::fmt::Debug for ExplainAnalyzer<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExplainAnalyzer")
+            .field("expression_engine", &self.expression_engine)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> ExplainAnalyzer<'a> {
+    /// Create a new analyzer with the given capability registry and expression engine.
+    pub fn new(
+        registry: &'a dyn CapabilityRegistry,
+        expression_engine: &'a ExpressionEngine,
+    ) -> Self {
+        Self {
+            registry,
+            expression_engine,
+        }
+    }
+
+    /// Produce a static analysis trace (no expression evaluation).
+    pub fn analyze(&self, _spec: &CompositionSpec) -> ExplanationTrace {
+        todo!("Task 3 implements this")
+    }
+
+    /// Produce a trace with simulated expression evaluation.
+    pub fn analyze_with_simulation(
+        &self,
+        _spec: &CompositionSpec,
+        _input: &SimulationInput,
+    ) -> ExplanationTrace {
+        todo!("Task 4 implements this")
+    }
+}
+```
+
+Create stub `crates/tasker-grammar/src/explain/tests.rs`:
+```rust
+// Tests added in Tasks 3 and 4.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tasker-grammar/src/explain/ crates/tasker-grammar/src/lib.rs
+git commit -m "feat(TAS-344): add explain module types and analyzer stub
+
+ExplanationTrace, InvocationTrace, EnvelopeSnapshot, ExpressionReference,
+SimulationInput, OutcomeSummary types. ExplainAnalyzer struct with stub
+methods. Module registered in tasker-grammar lib.rs."
+```
+
+---
+
+## Task 3: ExplainAnalyzer Static Analysis
+
+Implement `ExplainAnalyzer::analyze()` — the static trace mode with no expression evaluation.
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/explain/analyzer.rs`
+- Modify: `crates/tasker-grammar/src/explain/tests.rs`
+
+**Reference files (read, don't modify):**
+- `crates/tasker-grammar/src/validation/validator.rs` — `CompositionValidator`, `extract_expression()`, expression field mapping per category (lines 431-489)
+- `crates/tasker-grammar/src/executor/mod.rs` — `build_envelope()` function (lines 400-428)
+- `crates/tasker-grammar/src/types/composition.rs` — `CompositionSpec`, `CapabilityInvocation`
+
+- [ ] **Step 1: Write failing tests for static analysis**
+
+Add to `crates/tasker-grammar/src/explain/tests.rs`:
+
+```rust
+use std::collections::HashMap;
+use serde_json::json;
+
+use crate::explain::{ExplainAnalyzer, SimulationInput};
+use crate::types::{
+    CapabilityDeclaration, CapabilityInvocation, CompositionSpec, GrammarCategoryKind,
+    MutationProfile, OutcomeDeclaration,
+};
+use crate::ExpressionEngine;
+
+fn test_registry() -> HashMap<String, CapabilityDeclaration> {
+    let mut reg = HashMap::new();
+    reg.insert("transform".to_owned(), CapabilityDeclaration {
+        name: "transform".to_owned(),
+        grammar_category: GrammarCategoryKind::Transform,
+        description: "Pure data transformation".to_owned(),
+        config_schema: json!({
+            "type": "object",
+            "required": ["output", "filter"],
+            "properties": {
+                "output": {"type": "object"},
+                "filter": {"type": "string"}
+            }
+        }),
+        mutation_profile: MutationProfile::NonMutating,
+        tags: vec![],
+        version: "1.0.0".to_owned(),
+    });
+    reg.insert("persist".to_owned(), CapabilityDeclaration {
+        name: "persist".to_owned(),
+        grammar_category: GrammarCategoryKind::Persist,
+        description: "Write data to a resource".to_owned(),
+        config_schema: json!({
+            "type": "object",
+            "required": ["resource", "data"],
+            "properties": {
+                "resource": {"type": "object"},
+                "data": {"type": "object"}
+            }
+        }),
+        mutation_profile: MutationProfile::Mutating { supports_idempotency_key: true },
+        tags: vec![],
+        version: "1.0.0".to_owned(),
+    });
+    reg.insert("assert".to_owned(), CapabilityDeclaration {
+        name: "assert".to_owned(),
+        grammar_category: GrammarCategoryKind::Assert,
+        description: "Boolean assertion gate".to_owned(),
+        config_schema: json!({
+            "type": "object",
+            "required": ["filter"],
+            "properties": {
+                "filter": {"type": "string"},
+                "error": {"type": "string"}
+            }
+        }),
+        mutation_profile: MutationProfile::NonMutating,
+        tags: vec![],
+        version: "1.0.0".to_owned(),
+    });
+    reg
+}
+
+fn test_engine() -> ExpressionEngine {
+    ExpressionEngine::with_defaults()
+}
+
+#[test]
+fn analyze_single_transform() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Test outcome".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "transform".to_owned(),
+            config: json!({
+                "output": {"type": "object", "properties": {"result": {"type": "string"}}},
+                "filter": "{result: .context.name}"
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert!(!trace.simulated);
+    assert_eq!(trace.name, Some("test".to_owned()));
+    assert_eq!(trace.invocations.len(), 1);
+
+    let inv = &trace.invocations[0];
+    assert_eq!(inv.index, 0);
+    assert_eq!(inv.capability, "transform");
+    assert_eq!(inv.category, GrammarCategoryKind::Transform);
+    assert!(!inv.checkpoint);
+    assert!(!inv.is_mutating);
+    assert!(!inv.envelope_available.has_prev);
+    assert!(inv.envelope_available.prev_source.is_none());
+    assert!(inv.output_schema.is_some());
+    assert!(inv.simulated_output.is_none());
+
+    // Should have one expression reference for the filter
+    assert_eq!(inv.expressions.len(), 1);
+    assert_eq!(inv.expressions[0].field_path, "config.filter");
+    assert!(inv.expressions[0].referenced_paths.contains(&".context.name".to_owned()));
+}
+
+#[test]
+fn analyze_multi_invocation_chain() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("chain".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Chained".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object", "properties": {"x": {"type": "number"}}},
+                    "filter": "{x: .context.value}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object", "properties": {"doubled": {"type": "number"}}},
+                    "filter": "{doubled: (.prev.x * 2)}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert_eq!(trace.invocations.len(), 2);
+
+    // First invocation: no .prev
+    assert!(!trace.invocations[0].envelope_available.has_prev);
+
+    // Second invocation: .prev comes from invocation 0
+    let inv1 = &trace.invocations[1];
+    assert!(inv1.envelope_available.has_prev);
+    assert!(inv1.envelope_available.prev_source.as_ref().unwrap().contains("invocation 0"));
+    assert!(inv1.envelope_available.prev_schema.is_some());
+    assert!(inv1.expressions[0].referenced_paths.contains(&".prev.x".to_owned()));
+}
+
+#[test]
+fn analyze_checkpoint_and_mutating() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Persist test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": {"type": "postgres", "table": "orders"},
+                "data": {"expression": ".prev.payload"}
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    let inv = &trace.invocations[0];
+    assert!(inv.checkpoint);
+    assert!(inv.is_mutating);
+    assert_eq!(inv.expressions.len(), 1);
+    assert_eq!(inv.expressions[0].field_path, "config.data.expression");
+}
+
+#[test]
+fn analyze_empty_composition() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Empty".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    assert!(trace.invocations.is_empty());
+    assert!(trace.validation.iter().any(|f| f.code == "EMPTY_COMPOSITION"));
+}
+
+#[test]
+fn analyze_missing_capability() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Bad ref".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "nonexistent".to_owned(),
+            config: json!({}),
+            checkpoint: false,
+        }],
+    };
+
+    let trace = analyzer.analyze(&spec);
+    // Should still produce a trace entry (partial trace)
+    assert_eq!(trace.invocations.len(), 1);
+    assert!(trace.validation.iter().any(|f| f.code == "MISSING_CAPABILITY"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(analyze_)'`
+Expected: FAIL — `analyze` returns `todo!()`.
+
+- [ ] **Step 3: Implement `ExplainAnalyzer::analyze()`**
+
+Replace the stub in `crates/tasker-grammar/src/explain/analyzer.rs` with the full implementation. Key logic:
+
+1. Run `CompositionValidator::validate()`, capture findings.
+2. For degenerate cases (empty, too many), return trace with empty invocations + findings.
+3. Walk invocations, for each:
+   - Resolve capability from registry (produce partial entry if missing).
+   - Build `EnvelopeSnapshot` tracking `.prev` source and schema from prior invocation.
+   - Extract expressions from category-specific config fields (reuse the field mapping from `validator.rs` lines 431-439).
+   - For each expression, call `extract_references()`.
+   - Extract output schema (transform: `config.output`).
+   - Track output schema as `prev_schema` for the next invocation.
+
+The analyzer uses the same `extract_expression()` helper pattern as the validator for extracting jaq expressions from flat strings vs ExpressionField objects.
+
+Refer to:
+- `crates/tasker-grammar/src/validation/validator.rs` lines 174-184 for `extract_expression()`
+- `crates/tasker-grammar/src/validation/validator.rs` lines 431-439 for expression field mapping per category (top-level expression fields)
+- `crates/tasker-grammar/src/validation/validator.rs` lines 464-489 for emit metadata expressions (nested under `config.metadata`: `correlation_id`, `idempotency_key`) — these must also be extracted
+- `crates/tasker-grammar/src/validation/validator.rs` lines 616-631 for `extract_output_schema()`
+
+**Important**: The `Validate` category has no expression fields (schema-based, not expression-based). Its `expressions` list should be empty.
+
+**Error handling for `extract_references`**: If `extract_references` returns an error for a syntactically invalid expression, the analyzer should skip reference extraction for that expression (the syntax error is already captured by the validator's findings). Record an empty `referenced_paths` for that expression.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(analyze_)'`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets --all-features -p tasker-grammar`
+Expected: Zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-grammar/src/explain/
+git commit -m "feat(TAS-344): implement ExplainAnalyzer static analysis
+
+Walks the invocation chain producing EnvelopeSnapshot, ExpressionReference,
+and output schema tracking. Includes validation findings. Handles degenerate
+cases (empty composition, missing capabilities) with partial traces."
+```
+
+---
+
+## Task 4: ExplainAnalyzer Simulated Evaluation
+
+Implement `ExplainAnalyzer::analyze_with_simulation()` — evaluating jaq expressions against sample data.
+
+**Files:**
+- Modify: `crates/tasker-grammar/src/explain/analyzer.rs`
+- Modify: `crates/tasker-grammar/src/explain/tests.rs`
+
+**Reference files:**
+- `crates/tasker-grammar/src/executor/mod.rs` — `build_envelope()` (lines 400-428), execution loop pattern (lines 297-379)
+
+- [ ] **Step 1: Write failing tests for simulation**
+
+Add to `crates/tasker-grammar/src/explain/tests.rs`:
+
+```rust
+#[test]
+fn analyze_with_simulation_threads_data() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: Some("sim_test".to_owned()),
+        outcome: OutcomeDeclaration {
+            description: "Simulation".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{doubled: (.context.value * 2)}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{result: (.prev.doubled + 1)}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let input = SimulationInput {
+        context: json!({"value": 21}),
+        deps: json!({}),
+        step: json!({"name": "test_step"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    assert!(trace.simulated);
+
+    // First invocation: .context.value=21, doubled=42
+    let inv0 = &trace.invocations[0];
+    assert_eq!(inv0.simulated_output, Some(json!({"doubled": 42})));
+    assert_eq!(inv0.expressions[0].simulated_result, Some(json!({"doubled": 42})));
+
+    // Second invocation: .prev.doubled=42, result=43
+    let inv1 = &trace.invocations[1];
+    assert_eq!(inv1.simulated_output, Some(json!({"result": 43})));
+}
+
+#[test]
+fn analyze_with_simulation_mock_outputs() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Mock test".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "persist".to_owned(),
+                config: json!({
+                    "resource": {"type": "postgres", "table": "orders"},
+                    "data": {"expression": ".context.order"}
+                }),
+                checkpoint: true,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{id: .prev.inserted_id}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let mut mock_outputs = HashMap::new();
+    mock_outputs.insert(0, json!({"inserted_id": 42}));
+
+    let input = SimulationInput {
+        context: json!({"order": {"item": "widget"}}),
+        deps: json!({}),
+        step: json!({"name": "persist_step"}),
+        mock_outputs,
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+
+    // Persist invocation used mock output
+    let inv0 = &trace.invocations[0];
+    assert!(inv0.mock_output_used);
+    assert_eq!(inv0.simulated_output, Some(json!({"inserted_id": 42})));
+
+    // Transform reads .prev.inserted_id = 42
+    let inv1 = &trace.invocations[1];
+    assert!(!inv1.mock_output_used);
+    assert_eq!(inv1.simulated_output, Some(json!({"id": 42})));
+}
+
+#[test]
+fn analyze_with_simulation_missing_mock() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "No mock".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "persist".to_owned(),
+            config: json!({
+                "resource": {"type": "postgres", "table": "orders"},
+                "data": {"expression": ".context.order"}
+            }),
+            checkpoint: true,
+        }],
+    };
+
+    let input = SimulationInput {
+        context: json!({"order": {"item": "widget"}}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(), // no mock for index 0
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    let inv = &trace.invocations[0];
+    assert!(!inv.mock_output_used);
+    // .prev becomes null — should have info finding about missing mock
+    assert!(trace.validation.iter().any(|f| f.message.contains("mock")));
+}
+
+#[test]
+fn analyze_with_simulation_assert_passthrough() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Assert passthrough".to_owned(),
+            output_schema: json!({"type": "object"}),
+        },
+        invocations: vec![
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{x: .context.value}"
+                }),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "assert".to_owned(),
+                config: json!({"filter": "(.prev.x > 0)", "error": "must be positive"}),
+                checkpoint: false,
+            },
+            CapabilityInvocation {
+                capability: "transform".to_owned(),
+                config: json!({
+                    "output": {"type": "object"},
+                    "filter": "{result: .prev.x}"
+                }),
+                checkpoint: false,
+            },
+        ],
+    };
+
+    let input = SimulationInput {
+        context: json!({"value": 5}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+
+    // Assert passes .prev through unchanged
+    let assert_inv = &trace.invocations[1];
+    assert_eq!(assert_inv.simulated_output, Some(json!({"x": 5})));
+
+    // Next transform reads .prev.x which is still 5 from the first transform
+    let final_inv = &trace.invocations[2];
+    assert_eq!(final_inv.simulated_output, Some(json!({"result": 5})));
+}
+
+#[test]
+fn analyze_with_simulation_expression_failure() {
+    let registry = test_registry();
+    let engine = test_engine();
+    let analyzer = ExplainAnalyzer::new(&registry, &engine);
+
+    let spec = CompositionSpec {
+        name: None,
+        outcome: OutcomeDeclaration {
+            description: "Eval failure".to_owned(),
+            output_schema: json!({}),
+        },
+        invocations: vec![CapabilityInvocation {
+            capability: "transform".to_owned(),
+            config: json!({
+                "output": {"type": "object"},
+                "filter": ".prev.missing_field | .nested"
+            }),
+            checkpoint: false,
+        }],
+    };
+
+    let input = SimulationInput {
+        context: json!({}),
+        deps: json!({}),
+        step: json!({"name": "test"}),
+        mock_outputs: HashMap::new(),
+    };
+
+    let trace = analyzer.analyze_with_simulation(&spec, &input);
+    // Should have a warning about the evaluation failure
+    let inv = &trace.invocations[0];
+    // simulated_output should be null or absent
+    // trace should continue (not panic)
+    assert!(trace.simulated);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(analyze_with_simulation)'`
+Expected: FAIL — `analyze_with_simulation` returns `todo!()`.
+
+- [ ] **Step 3: Implement `analyze_with_simulation()`**
+
+In `crates/tasker-grammar/src/explain/analyzer.rs`, implement the simulation path. Key logic:
+
+1. Start with the same static analysis pass.
+2. Additionally, build an envelope at each step using the sample data + accumulated outputs. Include accumulated invocation outputs under `.deps.invocations.{idx}` (same as the real executor's `build_envelope` at `executor/mod.rs` lines 400-428) so that expressions referencing prior invocation outputs via `.deps.invocations.0.field` work correctly in simulation.
+3. For transform: evaluate the `filter` expression against the envelope, use result as simulated output and next `.prev`.
+4. For validate/assert: pass `.prev` through unchanged as simulated output.
+5. For persist/acquire/emit: evaluate data/params/payload expressions to record `simulated_result` on the ExpressionReference, then check `mock_outputs` for the `.prev` value. If no mock, set `.prev` to `null` and add an info-level `ValidationFinding`.
+6. On expression evaluation failure: record `null` as `simulated_result`, add a warning finding, continue.
+
+Factor out shared logic between `analyze()` and `analyze_with_simulation()` into internal helpers to avoid duplication.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar -E 'test(analyze_)'`
+Expected: All tests PASS (both static and simulation tests).
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets --all-features -p tasker-grammar`
+Expected: Zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-grammar/src/explain/
+git commit -m "feat(TAS-344): implement simulated evaluation in ExplainAnalyzer
+
+Evaluates jaq expressions against user-provided sample data, threading
+computed values through the chain. Mock outputs for side-effecting
+capabilities. Assert/validate pass .prev through unchanged. Graceful
+handling of expression eval failures."
+```
+
+---
+
+## Task 5: SDK Function
+
+Add `explain_composition()` to `tasker_sdk::grammar_query` with serializable return types.
+
+**Files:**
+- Modify: `crates/tasker-sdk/src/grammar_query.rs`
+
+**Reference:** Existing `validate_composition_yaml()` at lines 221-285 for the pattern.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/tasker-sdk/src/grammar_query.rs`:
+
+```rust
+#[test]
+fn explain_composition_static() {
+    let yaml = r#"
+name: test
+outcome:
+  description: Test outcome
+  output_schema: {}
+invocations:
+  - capability: transform
+    config:
+      output:
+        type: object
+        properties:
+          x:
+            type: string
+        required: [x]
+      filter: "{x: .context.name}"
+    checkpoint: false
+"#;
+    let explanation = explain_composition(yaml, None);
+    assert!(!explanation.simulated);
+    assert_eq!(explanation.invocations.len(), 1);
+    assert_eq!(explanation.invocations[0].capability, "transform");
+    assert_eq!(explanation.invocations[0].category, "Transform");
+    assert!(!explanation.invocations[0].expressions.is_empty());
+}
+
+#[test]
+fn explain_composition_with_simulation() {
+    let yaml = r#"
+name: sim
+outcome:
+  description: Simulation
+  output_schema: {}
+invocations:
+  - capability: transform
+    config:
+      output: {type: object}
+      filter: "{doubled: (.context.value * 2)}"
+    checkpoint: false
+"#;
+    let sim = tasker_grammar::explain::SimulationInput {
+        context: serde_json::json!({"value": 21}),
+        deps: serde_json::json!({}),
+        step: serde_json::json!({"name": "test"}),
+        mock_outputs: std::collections::HashMap::new(),
+    };
+    let explanation = explain_composition(yaml, Some(sim));
+    assert!(explanation.simulated);
+    assert_eq!(
+        explanation.invocations[0].simulated_output,
+        Some(serde_json::json!({"doubled": 42}))
+    );
+}
+
+#[test]
+fn explain_composition_invalid_yaml() {
+    let explanation = explain_composition("not: valid: yaml: [[[", None);
+    assert!(explanation
+        .findings
+        .iter()
+        .any(|f| f.code == "PARSE_ERROR"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run --features test-messaging -p tasker-sdk -E 'test(explain_composition)'`
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Add serializable types and `explain_composition()` function**
+
+Add to `crates/tasker-sdk/src/grammar_query.rs`:
+
+1. New return types: `CompositionExplanation`, `InvocationExplanation`, `EnvelopeSnapshotInfo`, `ExpressionReferenceInfo`, `OutcomeInfo` — all `#[derive(Debug, Serialize)]`. These mirror the grammar-layer types with `GrammarCategoryKind` → `String` and `ValidationFinding` → `CompositionFinding` conversions.
+
+2. The `explain_composition()` function following the same pattern as `validate_composition_yaml()`:
+   - Parse YAML/JSON (try YAML first, fall back to JSON)
+   - On parse failure, return explanation with PARSE_ERROR finding
+   - Construct `ExplainAnalyzer` with `standard_capability_registry()` and `ExpressionEngine::with_defaults()`
+   - Call `analyze()` or `analyze_with_simulation()` based on whether `simulation` is `Some`
+   - Map `ExplanationTrace` to `CompositionExplanation`
+
+Re-export `SimulationInput` from tasker-grammar so MCP/CLI layers can construct it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run --features test-messaging -p tasker-sdk -E 'test(explain_composition)'`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets --all-features -p tasker-sdk`
+Expected: Zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-sdk/src/grammar_query.rs
+git commit -m "feat(TAS-344): add explain_composition to SDK grammar_query
+
+Serializable CompositionExplanation type and explain_composition() function
+wrapping ExplainAnalyzer. Supports static analysis and simulated evaluation.
+Re-exports SimulationInput from tasker-grammar."
+```
+
+---
+
+## Task 6: MCP Tool
+
+Add the `composition_explain` Tier 1 offline tool to `tasker-mcp`.
+
+**Files:**
+- Modify: `crates/tasker-mcp/src/tools/params.rs` (after line 796)
+- Modify: `crates/tasker-mcp/src/tools/developer.rs` (after line 368, imports at line ~18)
+- Modify: `crates/tasker-mcp/src/server.rs` (after line 458)
+- Modify: `crates/tasker-mcp/tests/mcp_protocol_test.rs` (update assertions)
+
+**Reference:** Existing `composition_validate` pattern at `developer.rs:364-368`, `params.rs:788-796`, `server.rs:448-458`.
+
+- [ ] **Step 1: Add parameter struct**
+
+Add to `crates/tasker-mcp/src/tools/params.rs` after the `CompositionValidateParams` struct (after line 796):
+
+```rust
+// ── composition_explain ──
+
+/// Parameters for the `composition_explain` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CompositionExplainParams {
+    /// Composition spec as YAML or JSON string.
+    #[schemars(
+        description = "Composition spec as YAML or JSON string. Must include name, outcome (with output_schema), and invocations array."
+    )]
+    pub composition_yaml: String,
+
+    /// Optional sample context data as JSON string for simulated evaluation.
+    /// Populates .context in the composition envelope.
+    #[schemars(description = "Sample task-level input data as JSON string. Populates .context in the envelope for simulated evaluation.")]
+    #[serde(default)]
+    pub sample_context: Option<String>,
+
+    /// Optional sample dependency results as JSON string.
+    /// Populates .deps in the composition envelope.
+    #[schemars(description = "Sample dependency step results as JSON string. Populates .deps in the envelope.")]
+    #[serde(default)]
+    pub sample_deps: Option<String>,
+
+    /// Optional sample step metadata as JSON string.
+    /// Populates .step in the composition envelope.
+    #[schemars(description = "Sample step metadata as JSON string. Populates .step in the envelope.")]
+    #[serde(default)]
+    pub sample_step: Option<String>,
+
+    /// Optional mock outputs for side-effecting invocations as JSON string.
+    /// Object keyed by invocation index: {"0": {"id": 123}, "2": {"status": "sent"}}
+    #[schemars(description = "Mock outputs for side-effecting invocations as JSON object keyed by invocation index (e.g. {\"0\": {\"id\": 123}}). Used as .prev for subsequent invocations.")]
+    #[serde(default)]
+    pub mock_outputs: Option<String>,
+}
+```
+
+- [ ] **Step 2: Add handler function**
+
+Add to `crates/tasker-mcp/src/tools/developer.rs` after `composition_validate` (after line 368):
+
+```rust
+pub fn composition_explain(params: CompositionExplainParams) -> String {
+    use std::collections::HashMap;
+    use tasker_grammar::SimulationInput;
+
+    // Build SimulationInput if any sample data provided
+    let simulation = if params.sample_context.is_some()
+        || params.sample_deps.is_some()
+        || params.sample_step.is_some()
+        || params.mock_outputs.is_some()
+    {
+        let context = params
+            .sample_context
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let deps = params
+            .sample_deps
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let step = params
+            .sample_step
+            .as_deref()
+            .map(|s| serde_json::from_str(s).unwrap_or(serde_json::Value::Null))
+            .unwrap_or(serde_json::Value::Null);
+        let mock_outputs: HashMap<usize, serde_json::Value> = params
+            .mock_outputs
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(s).ok())
+            .map(|map| {
+                map.into_iter()
+                    .filter_map(|(k, v)| k.parse::<usize>().ok().map(|idx| (idx, v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Some(SimulationInput {
+            context,
+            deps,
+            step,
+            mock_outputs,
+        })
+    } else {
+        None
+    };
+
+    let explanation = grammar_query::explain_composition(&params.composition_yaml, simulation);
+    serde_json::to_string_pretty(&explanation)
+        .unwrap_or_else(|e| error_json("serialization_error", &e.to_string()))
+}
+```
+
+Add `CompositionExplainParams` to the imports from `crate::tools::params`.
+
+- [ ] **Step 3: Register the tool in server.rs**
+
+Add after the `composition_validate` tool registration (after line 458 in `crates/tasker-mcp/src/server.rs`):
+
+```rust
+/// Explain data flow through a composition spec.
+#[tool(
+    name = "composition_explain",
+    description = "Analyze and explain data flow through a CompositionSpec. Shows how data threads through invocations via the envelope (.context, .deps, .prev, .step), which jaq expressions reference which fields, checkpoint placement, and output schemas. Optionally evaluates expressions against sample data for simulated execution. Works offline."
+)]
+pub async fn composition_explain(
+    &self,
+    Parameters(params): Parameters<CompositionExplainParams>,
+) -> String {
+    developer::composition_explain(params)
+}
+```
+
+Update the Tier 1 tools doc comment in server.rs to mention 14 tools and include `composition_explain`.
+
+- [ ] **Step 4: Update test assertions**
+
+In `crates/tasker-mcp/tests/mcp_protocol_test.rs`:
+- Add `"composition_explain"` to the offline tools list (alphabetically before `"composition_validate"`).
+- Update assertion: 13 → 14 Tier 1 tools.
+- Update full tool count: 36 → 37.
+- Update T1+profile+T2 count: 30 → 31.
+- Update doc comment mentioning tool counts.
+
+- [ ] **Step 5: Verify compilation and tests**
+
+Run: `cargo check --all-features -p tasker-mcp`
+Run: `cargo clippy --all-targets --all-features -p tasker-mcp`
+Expected: Compiles, zero clippy warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tasker-mcp/
+git commit -m "feat(TAS-344): add composition_explain MCP tool
+
+Tier 1 offline tool for data flow visualization. Accepts composition
+YAML with optional sample data for simulated evaluation. Brings Tier 1
+count from 13 to 14."
+```
+
+---
+
+## Task 7: CLI Command
+
+Add `tasker-ctl grammar composition explain` subcommand.
+
+**Files:**
+- Modify: `crates/tasker-ctl/src/commands/grammar.rs`
+
+**Reference:** Existing `composition_validate` at grammar.rs lines 60-69 (enum variant) and lines 84-88 (dispatch) and the validate handler (lines ~270-365).
+
+- [ ] **Step 1: Add Explain variant to CompositionCommands**
+
+In `crates/tasker-ctl/src/commands/grammar.rs`, add the Explain variant after Validate (line 69):
+
+```rust
+/// Explain data flow through a composition spec file
+Explain {
+    /// Path to the composition file
+    path: PathBuf,
+
+    /// Explain only the named step's composition within a full task template
+    #[arg(long)]
+    step: Option<String>,
+
+    /// Sample context data (inline JSON or @path/to/file.json)
+    #[arg(long)]
+    sample_context: Option<String>,
+
+    /// Sample dependency results (inline JSON or @path/to/file.json)
+    #[arg(long)]
+    sample_deps: Option<String>,
+
+    /// Sample step metadata (inline JSON or @path/to/file.json)
+    #[arg(long)]
+    sample_step: Option<String>,
+
+    /// Mock outputs for side-effecting invocations (inline JSON or @path/to/file.json)
+    #[arg(long)]
+    mock_outputs: Option<String>,
+},
+```
+
+- [ ] **Step 2: Add dispatch arm**
+
+In the `handle_grammar_command` match (line 84-88), add the Explain arm:
+
+```rust
+CompositionCommands::Explain {
+    path,
+    step,
+    sample_context,
+    sample_deps,
+    sample_step,
+    mock_outputs,
+} => composition_explain(
+    &path,
+    step.as_deref(),
+    sample_context.as_deref(),
+    sample_deps.as_deref(),
+    sample_step.as_deref(),
+    mock_outputs.as_deref(),
+    format,
+),
+```
+
+- [ ] **Step 3: Implement the handler function**
+
+Add the `composition_explain` handler function. It should:
+
+1. Read the file at `path`.
+2. If `--step` is provided, extract the step's composition from the template (same logic as `composition_validate` handler at lines 270-324).
+3. Parse `--sample-context`, `--sample-deps`, `--sample-step`, `--mock-outputs` — for each, if it starts with `@`, read the file; otherwise parse as inline JSON.
+4. Build `SimulationInput` if any sample data is provided.
+5. Call `tasker_sdk::grammar_query::explain_composition()`.
+6. For JSON format: print the full `CompositionExplanation`.
+7. For table format: print a summary showing the invocation chain with key details (index, capability, category, checkpoint, `.prev` source, expression count, and simulated values if present).
+
+Helper for `@path` loading:
+
+```rust
+fn load_json_arg(value: &str) -> Result<serde_json::Value, tasker_client::ClientError> {
+    let content = if let Some(path) = value.strip_prefix('@') {
+        std::fs::read_to_string(path)
+            .map_err(|e| tasker_client::ClientError::Internal(format!("Failed to read {path}: {e}")))?
+    } else {
+        value.to_owned()
+    };
+    serde_json::from_str(&content)
+        .map_err(|e| tasker_client::ClientError::Internal(format!("Invalid JSON: {e}")))
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check --all-features -p tasker-ctl`
+Run: `cargo clippy --all-targets --all-features -p tasker-ctl`
+Expected: Compiles, zero clippy warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tasker-ctl/src/commands/grammar.rs
+git commit -m "feat(TAS-344): add grammar composition explain CLI command
+
+Supports --sample-context, --sample-deps, --sample-step, --mock-outputs
+flags with inline JSON or @path/to/file.json syntax. Table and JSON
+output formats."
+```
+
+---
+
+## Task 8: Final Verification
+
+Full workspace validation.
+
+- [ ] **Step 1: Run all grammar tests**
+
+Run: `cargo nextest run --features test-messaging -p tasker-grammar`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run all SDK tests**
+
+Run: `cargo nextest run --features test-messaging -p tasker-sdk`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run workspace clippy**
+
+Run: `cargo clippy --all-targets --all-features --workspace`
+Expected: Zero warnings.
+
+- [ ] **Step 4: Run workspace check**
+
+Run: `cargo check --all-features --workspace`
+Expected: Compiles.
+
+- [ ] **Step 5: Verify MCP tests compile (they require services for full run)**
+
+Run: `cargo nextest run --features test-messaging -p tasker-mcp --lib`
+Expected: Library tests pass (protocol tests may need services).

--- a/docs/superpowers/specs/2026-03-20-tas-344-composition-explain-trace-design.md
+++ b/docs/superpowers/specs/2026-03-20-tas-344-composition-explain-trace-design.md
@@ -34,6 +34,9 @@ New module `explain` in `tasker-grammar` containing the core analysis engine.
 
 #### Core Types
 
+These types live in `tasker-grammar` and use grammar-native types (`GrammarCategoryKind`, etc.).
+The SDK layer converts them to serializable mirrors with string representations (e.g., `GrammarCategoryKind::Transform` → `"Transform"`), following the same pattern as `ValidationResult` → `CompositionValidationReport`.
+
 ```rust
 /// Complete trace of data flow through a composition.
 pub struct ExplanationTrace {
@@ -61,8 +64,9 @@ pub struct InvocationTrace {
     pub index: usize,
     /// Capability name.
     pub capability: String,
-    /// Grammar category (Transform, Persist, etc.).
-    pub category: String,
+    /// Grammar category — uses GrammarCategoryKind enum at grammar layer;
+    /// SDK mirror converts to String.
+    pub category: GrammarCategoryKind,
     /// Whether this is a checkpoint boundary.
     pub checkpoint: bool,
     /// Whether this capability is mutating.
@@ -155,14 +159,26 @@ impl<'a> ExplainAnalyzer<'a> {
 #### Analysis Flow
 
 1. Run `CompositionValidator::validate()` and include findings in the trace.
-2. Walk invocations in order. For each:
+2. **Degenerate inputs**: If the composition is empty (`EMPTY_COMPOSITION`) or exceeds limits (`TOO_MANY_INVOCATIONS`), return a trace with zero invocation entries and the validation findings. The trace is always produced — it may just have an empty `invocations` list.
+3. Walk invocations in order. For each:
    a. Resolve capability from registry (skip if missing, note in validation findings).
    b. Build `EnvelopeSnapshot` — track what `.prev` is based on prior invocation's output.
-   c. Extract jaq expressions from config fields (category-specific: `filter` for transform/assert, `data`/`params`/`payload` for action capabilities, plus `validate_success`, `result_shape`, metadata expressions for emit).
+   c. Extract jaq expressions from config fields. Expression fields are category-specific, matching the validator's existing mapping:
+      - **Transform**: `filter`
+      - **Assert**: `filter`
+      - **Persist**: `data`, `validate_success`, `result_shape`
+      - **Acquire**: `params`, `validate_success`, `result_shape`
+      - **Emit**: `payload`, `condition`, `validate_success`, `result_shape`, plus metadata expressions (`correlation_id`, `idempotency_key`)
+      - **Validate**: no expressions (schema-based, not expression-based)
    d. For each expression, call `ExpressionEngine::extract_references()` to find envelope path references.
    e. Determine output schema (transform: `config.output`; others: future extension).
-   f. **If simulating**: build the envelope from sample data + accumulated outputs, evaluate expressions, record results. For pure capabilities, use evaluated output as next `.prev`. For side-effecting capabilities, use mock output from `SimulationInput` if provided; otherwise `.prev` becomes `null`.
-3. Assemble `ExplanationTrace`.
+   f. **If simulating**: build the envelope from sample data + accumulated outputs, evaluate expressions, record results. Simulation semantics per category:
+      - **Transform**: evaluate the `filter` expression, use result as next `.prev`.
+      - **Validate**: pass `.prev` through unchanged (validate checks conformance, doesn't transform).
+      - **Assert**: pass `.prev` through unchanged (assert is a gate, not a transformer).
+      - **Persist/Acquire/Emit** (side-effecting): evaluate data/params/payload expressions to show what *would* be sent, then use mock output from `SimulationInput.mock_outputs` as next `.prev`. If no mock provided, `.prev` becomes `null` and an info-level finding is recorded.
+   g. **Expression evaluation failures during simulation**: If a jaq expression fails (e.g., `.prev.missing_field` on an object without that field), record the error as an `ExpressionReference.simulated_result` of `null` and add a warning-level finding with the error details. Simulation continues — a single expression failure does not abort the trace.
+4. Assemble `ExplanationTrace`.
 
 #### Expression Reference Extraction
 
@@ -176,9 +192,17 @@ impl ExpressionEngine {
 }
 ```
 
-**Implementation**: Parse the expression using jaq's parser, walk the AST looking for path access chains rooted at `.context`, `.deps`, `.prev`, or `.step`. Extract to practical depth — `.context.order_id` yes, but dynamic expressions like `.context | keys` report `.context` as the reference.
+**Implementation**: Regex-based extraction. jaq-core compiles expressions to an opaque `Filter` type with no walkable AST, so AST-based extraction is not feasible with the current public API. Instead, scan the expression string for envelope path patterns using regex:
 
-**Fallback**: If jaq AST internals prove too unstable, fall back to regex-based extraction scanning for `\.context\b`, `\.deps\b`, `\.prev\b`, `\.step\b` with subsequent dotted path segments. The interface is the same regardless of implementation strategy.
+1. Match patterns rooted at the four envelope fields: `\.context`, `\.deps`, `\.prev`, `\.step`
+2. Follow with dotted path segments and/or bracket notation: `\.context\.order_id`, `\.deps\.step_a\.result`
+3. Deduplicate results
+
+The regex approach handles the common cases well — most jaq expressions in compositions use straightforward field access like `.context.order_id` or `.prev.items`. Dynamic patterns like `.context | keys` are captured as `.context` (the root reference). This is sufficient for data flow visualization.
+
+**Pattern**: `\.(context|deps|prev|step)(\.[a-zA-Z_][a-zA-Z0-9_]*)*`
+
+**Future enhancement**: If jaq-core exposes a public AST in a future version, `extract_references` can switch to AST walking behind the same interface.
 
 ### Layer 2: `tasker-sdk` — Grammar Query Function
 
@@ -191,7 +215,12 @@ pub fn explain_composition(
 ) -> CompositionExplanation;
 ```
 
-`CompositionExplanation` is a `Serialize`-deriving mirror of `ExplanationTrace`, following the same pattern as `CompositionValidationReport`. The function parses YAML/JSON, constructs `ExplainAnalyzer` with the standard capability registry and expression engine, and calls the appropriate analyze method.
+`CompositionExplanation` is a `Serialize`-deriving mirror of `ExplanationTrace`, following the same pattern as `CompositionValidationReport` mirroring `ValidationResult`. The mirror converts grammar-native types to serializable representations:
+- `GrammarCategoryKind` → `String` (e.g., `"Transform"`)
+- `ValidationFinding` (grammar) → `CompositionFinding` (SDK) with `Severity` enum → string
+- All other fields are already serializable (`Value`, `String`, `bool`, `Vec`, `Option`)
+
+The function parses YAML/JSON (trying YAML first, then JSON — same as `validate_composition_yaml`), constructs `ExplainAnalyzer` with the standard capability registry and expression engine, and calls the appropriate analyze method. Parse failures return a `CompositionExplanation` with an empty trace and a parse error finding.
 
 `SimulationInput` is re-exported from `tasker-grammar` since it's just `Value` fields and a `HashMap`.
 
@@ -201,8 +230,8 @@ pub fn explain_composition(
 
 ```rust
 pub struct CompositionExplainParams {
-    /// Composition YAML or JSON string.
-    pub composition: String,
+    /// Composition YAML or JSON string (matches existing composition_yaml field name).
+    pub composition_yaml: String,
     /// Optional sample context data (JSON string, parsed to Value).
     pub sample_context: Option<String>,
     /// Optional sample deps data (JSON string).
@@ -211,11 +240,14 @@ pub struct CompositionExplainParams {
     pub sample_step: Option<String>,
     /// Mock outputs for side-effecting invocations (JSON string).
     /// Object keyed by invocation index: {"2": {"id": 123}, "4": {"status": "sent"}}
+    /// Keys must be valid non-negative integers; invalid keys produce a warning finding
+    /// and are ignored. Keys referencing indices outside the invocation range are also
+    /// warned about but do not prevent analysis.
     pub mock_outputs: Option<String>,
 }
 ```
 
-Handler parses JSON params, constructs `SimulationInput` if any sample data is provided, calls `explain_composition()`, returns JSON.
+Handler parses JSON string params into `Value`/`HashMap`, constructs `SimulationInput` if any sample data is provided, calls `explain_composition()`, returns JSON. Mock output keys that fail to parse as `usize` produce a warning in the response.
 
 Registered alongside the existing 13 Tier 1 tools, bringing the count to 14.
 
@@ -225,6 +257,7 @@ Registered alongside the existing 13 Tier 1 tools, bringing the count to 14.
 tasker-ctl grammar composition explain <path> [--step <name>] \
     [--sample-context <json-or-path>] \
     [--sample-deps <json-or-path>] \
+    [--sample-step <json-or-path>] \
     [--mock-outputs <json-or-path>]
 ```
 
@@ -232,6 +265,7 @@ tasker-ctl grammar composition explain <path> [--step <name>] \
 - `--step <name>` — extract a specific step's composition from a full template (same as `composition validate --step`)
 - `--sample-context` — inline JSON or `@path/to/file.json`
 - `--sample-deps` — inline JSON or `@path/to/file.json`
+- `--sample-step` — inline JSON or `@path/to/file.json` (step metadata: name, attempt count)
 - `--mock-outputs` — inline JSON or `@path/to/file.json`
 
 **Table output**: Shows invocation chain with columns for index, capability, category, checkpoint, `.prev` source, expressions, and (when simulating) simulated values.
@@ -249,6 +283,9 @@ tasker-ctl grammar composition explain <path> [--step <name>] \
 - **Mock outputs**: Side-effecting invocations use mock values as `.prev` for subsequent steps
 - **Missing mock output**: Graceful degradation — `.prev` becomes null, noted in trace
 - **Invalid composition**: Partial trace produced alongside validation findings
+- **Degenerate inputs**: Empty composition produces trace with zero invocations and `EMPTY_COMPOSITION` finding
+- **Validate/assert pass-through**: During simulation, validate and assert pass `.prev` unchanged
+- **Expression evaluation failure**: Failed jaq expression records null result and warning finding, simulation continues
 - **`extract_references`**: Unit tests for various expression patterns (`.context.x`, `.prev | keys`, nested deps access, expressions with no envelope references)
 
 ### `tasker-sdk` (integration)

--- a/docs/superpowers/specs/2026-03-20-tas-344-composition-explain-trace-design.md
+++ b/docs/superpowers/specs/2026-03-20-tas-344-composition-explain-trace-design.md
@@ -1,0 +1,274 @@
+# TAS-344: Composition Explain Trace Output for Data Flow Visualization
+
+**Ticket**: TAS-344
+**Phase**: 3C (Validation Tooling)
+**Predecessors**: TAS-333 (CompositionValidator), TAS-334 (CompositionExecutor), TAS-342/343 (grammar discovery tools)
+**Successor**: TAS-345 (validate 3 modeled workflows through composition tooling pipeline)
+
+## Problem
+
+When compositions grow complex, developers and LLM agents need to understand how data flows from invocation to invocation. The existing `composition_validate` tool checks correctness but doesn't visualize the data threading chain. An agent drafting a composition in an MCP context needs to verify that its jaq expressions reference the right envelope fields and that data threads coherently through the chain — before committing to execution.
+
+## Solution
+
+Add a `composition_explain` tool that produces a structured trace of data flow through a composition. Two modes:
+
+1. **Static analysis** (always): Traces structure, envelope field availability, expression references, output schemas, and checkpoint placement.
+2. **Simulated evaluation** (opt-in): When sample data is provided, evaluates jaq expressions against real values and threads computed results through the chain, showing concrete data at each step.
+
+## Architecture
+
+Three layers following the pattern established in TAS-342/343:
+
+```
+tasker-grammar (ExplainAnalyzer)
+    ↓ used by
+tasker-sdk (grammar_query::explain_composition)
+    ↓ called by
+tasker-mcp (composition_explain tool) + tasker-ctl (grammar composition explain command)
+```
+
+### Layer 1: `tasker-grammar` — ExplainAnalyzer
+
+New module `explain` in `tasker-grammar` containing the core analysis engine.
+
+#### Core Types
+
+```rust
+/// Complete trace of data flow through a composition.
+pub struct ExplanationTrace {
+    /// Composition name (if declared).
+    pub name: Option<String>,
+    /// Declared outcome description and output schema.
+    pub outcome: OutcomeSummary,
+    /// Per-invocation trace entries, in execution order.
+    pub invocations: Vec<InvocationTrace>,
+    /// Validation findings (errors/warnings) from the underlying validator.
+    pub validation: Vec<ValidationFinding>,
+    /// Whether simulation was performed (sample data provided).
+    pub simulated: bool,
+}
+
+/// Summary of the declared outcome.
+pub struct OutcomeSummary {
+    pub description: String,
+    pub output_schema: Value,
+}
+
+/// Trace for a single capability invocation.
+pub struct InvocationTrace {
+    /// Position in the invocation chain (0-based).
+    pub index: usize,
+    /// Capability name.
+    pub capability: String,
+    /// Grammar category (Transform, Persist, etc.).
+    pub category: String,
+    /// Whether this is a checkpoint boundary.
+    pub checkpoint: bool,
+    /// Whether this capability is mutating.
+    pub is_mutating: bool,
+    /// Envelope fields available at this invocation.
+    pub envelope_available: EnvelopeSnapshot,
+    /// Jaq expressions found in config and which envelope paths they reference.
+    pub expressions: Vec<ExpressionReference>,
+    /// Declared output schema (if any — transforms declare this).
+    pub output_schema: Option<Value>,
+    /// Simulated output value (when sample data provided).
+    pub simulated_output: Option<Value>,
+    /// For side-effecting capabilities: whether a mock output was provided.
+    pub mock_output_used: bool,
+}
+
+/// What's available in the envelope at a given point in the chain.
+pub struct EnvelopeSnapshot {
+    /// Always true — task-level input.
+    pub context: bool,
+    /// Always true — dependency step results.
+    pub deps: bool,
+    /// Always true — step metadata.
+    pub step: bool,
+    /// Whether .prev is non-null at this point.
+    pub has_prev: bool,
+    /// Description of what .prev contains (e.g., "output of invocation 0 (transform)").
+    pub prev_source: Option<String>,
+    /// Schema of .prev if known (from prior invocation's output schema).
+    pub prev_schema: Option<Value>,
+}
+
+/// A jaq expression found in an invocation's config.
+pub struct ExpressionReference {
+    /// Config field path (e.g., "filter", "data.expression").
+    pub field_path: String,
+    /// The raw expression string.
+    pub expression: String,
+    /// Envelope paths referenced (e.g., [".context.order_id", ".prev.total"]).
+    pub referenced_paths: Vec<String>,
+    /// Simulated result value (when sample data provided).
+    pub simulated_result: Option<Value>,
+}
+```
+
+#### SimulationInput
+
+```rust
+/// Sample data for simulated evaluation.
+pub struct SimulationInput {
+    /// Sample task-level input — populates .context
+    pub context: Value,
+    /// Sample dependency results — populates .deps
+    pub deps: Value,
+    /// Sample step metadata — populates .step
+    pub step: Value,
+    /// Mock outputs for side-effecting invocations, keyed by invocation index.
+    /// Used as .prev for the next invocation when the capability can't be
+    /// evaluated purely (persist, acquire, emit).
+    pub mock_outputs: HashMap<usize, Value>,
+}
+```
+
+#### ExplainAnalyzer
+
+```rust
+pub struct ExplainAnalyzer<'a> {
+    registry: &'a dyn CapabilityRegistry,
+    expression_engine: &'a ExpressionEngine,
+}
+
+impl<'a> ExplainAnalyzer<'a> {
+    pub fn new(
+        registry: &'a dyn CapabilityRegistry,
+        expression_engine: &'a ExpressionEngine,
+    ) -> Self;
+
+    /// Produce a static analysis trace (no expression evaluation).
+    pub fn analyze(&self, spec: &CompositionSpec) -> ExplanationTrace;
+
+    /// Produce a trace with simulated expression evaluation.
+    pub fn analyze_with_simulation(
+        &self,
+        spec: &CompositionSpec,
+        input: &SimulationInput,
+    ) -> ExplanationTrace;
+}
+```
+
+#### Analysis Flow
+
+1. Run `CompositionValidator::validate()` and include findings in the trace.
+2. Walk invocations in order. For each:
+   a. Resolve capability from registry (skip if missing, note in validation findings).
+   b. Build `EnvelopeSnapshot` — track what `.prev` is based on prior invocation's output.
+   c. Extract jaq expressions from config fields (category-specific: `filter` for transform/assert, `data`/`params`/`payload` for action capabilities, plus `validate_success`, `result_shape`, metadata expressions for emit).
+   d. For each expression, call `ExpressionEngine::extract_references()` to find envelope path references.
+   e. Determine output schema (transform: `config.output`; others: future extension).
+   f. **If simulating**: build the envelope from sample data + accumulated outputs, evaluate expressions, record results. For pure capabilities, use evaluated output as next `.prev`. For side-effecting capabilities, use mock output from `SimulationInput` if provided; otherwise `.prev` becomes `null`.
+3. Assemble `ExplanationTrace`.
+
+#### Expression Reference Extraction
+
+New method on `ExpressionEngine`:
+
+```rust
+impl ExpressionEngine {
+    /// Extract envelope field references from a jaq expression.
+    /// Returns paths like [".context.order_id", ".prev.total", ".deps.step_a.result"]
+    pub fn extract_references(&self, expression: &str) -> Result<Vec<String>, ExpressionError>;
+}
+```
+
+**Implementation**: Parse the expression using jaq's parser, walk the AST looking for path access chains rooted at `.context`, `.deps`, `.prev`, or `.step`. Extract to practical depth — `.context.order_id` yes, but dynamic expressions like `.context | keys` report `.context` as the reference.
+
+**Fallback**: If jaq AST internals prove too unstable, fall back to regex-based extraction scanning for `\.context\b`, `\.deps\b`, `\.prev\b`, `\.step\b` with subsequent dotted path segments. The interface is the same regardless of implementation strategy.
+
+### Layer 2: `tasker-sdk` — Grammar Query Function
+
+New function in `tasker_sdk::grammar_query`:
+
+```rust
+pub fn explain_composition(
+    yaml_str: &str,
+    simulation: Option<SimulationInput>,
+) -> CompositionExplanation;
+```
+
+`CompositionExplanation` is a `Serialize`-deriving mirror of `ExplanationTrace`, following the same pattern as `CompositionValidationReport`. The function parses YAML/JSON, constructs `ExplainAnalyzer` with the standard capability registry and expression engine, and calls the appropriate analyze method.
+
+`SimulationInput` is re-exported from `tasker-grammar` since it's just `Value` fields and a `HashMap`.
+
+### Layer 3: MCP Tool and CLI Command
+
+#### MCP: `composition_explain` (Tier 1 offline tool)
+
+```rust
+pub struct CompositionExplainParams {
+    /// Composition YAML or JSON string.
+    pub composition: String,
+    /// Optional sample context data (JSON string, parsed to Value).
+    pub sample_context: Option<String>,
+    /// Optional sample deps data (JSON string).
+    pub sample_deps: Option<String>,
+    /// Optional sample step metadata (JSON string).
+    pub sample_step: Option<String>,
+    /// Mock outputs for side-effecting invocations (JSON string).
+    /// Object keyed by invocation index: {"2": {"id": 123}, "4": {"status": "sent"}}
+    pub mock_outputs: Option<String>,
+}
+```
+
+Handler parses JSON params, constructs `SimulationInput` if any sample data is provided, calls `explain_composition()`, returns JSON.
+
+Registered alongside the existing 13 Tier 1 tools, bringing the count to 14.
+
+#### CLI: `tasker-ctl grammar composition explain`
+
+```
+tasker-ctl grammar composition explain <path> [--step <name>] \
+    [--sample-context <json-or-path>] \
+    [--sample-deps <json-or-path>] \
+    [--mock-outputs <json-or-path>]
+```
+
+- `<path>` — path to composition YAML file
+- `--step <name>` — extract a specific step's composition from a full template (same as `composition validate --step`)
+- `--sample-context` — inline JSON or `@path/to/file.json`
+- `--sample-deps` — inline JSON or `@path/to/file.json`
+- `--mock-outputs` — inline JSON or `@path/to/file.json`
+
+**Table output**: Shows invocation chain with columns for index, capability, category, checkpoint, `.prev` source, expressions, and (when simulating) simulated values.
+
+**JSON output**: Full `CompositionExplanation` struct.
+
+## Testing Strategy
+
+### `tasker-grammar` (bulk of tests)
+
+- **Static analysis**: Simple transform-only composition — verify envelope snapshots, expression references, output schema tracking
+- **Multi-invocation chain**: Verify `.prev` source tracking progresses correctly
+- **Mixed pure + side-effecting**: Verify checkpoint marking, mutating flags
+- **Simulated evaluation**: Sample data threads through jaq expressions, simulated outputs recorded
+- **Mock outputs**: Side-effecting invocations use mock values as `.prev` for subsequent steps
+- **Missing mock output**: Graceful degradation — `.prev` becomes null, noted in trace
+- **Invalid composition**: Partial trace produced alongside validation findings
+- **`extract_references`**: Unit tests for various expression patterns (`.context.x`, `.prev | keys`, nested deps access, expressions with no envelope references)
+
+### `tasker-sdk` (integration)
+
+- Valid YAML, no simulation — verify serializable output structure
+- Valid YAML with simulation — verify sample data flows through
+- Invalid YAML — parse error handling
+
+### `tasker-mcp` (assertion updates)
+
+- Update Tier 1 tool count from 13 to 14
+- Update protocol test expectations
+
+### `tasker-ctl`
+
+No dedicated tests — CLI handler is a thin wrapper.
+
+## Non-Goals
+
+- Schema-derived synthetic data generation — user provides sample data
+- Full jaq expression static analysis (variable tracking, type inference) — bounded to path extraction
+- Runtime tracing of actual execution — this is design-time tooling
+- Backwards compatibility with the outdated InputMapping model


### PR DESCRIPTION
## Summary

- **ExplainAnalyzer** in `tasker-grammar` with two modes: static analysis (traces envelope field availability, expression references, output schemas, checkpoints) and simulated evaluation (evaluates jaq expressions against user-provided sample data, threads computed values through the chain)
- **SDK function** `explain_composition()` in `tasker-sdk` wrapping the analyzer with serializable return types
- **MCP tool** `composition_explain` as Tier 1 offline tool (14th), accepting composition YAML with optional sample data for simulation
- **CLI command** `tasker-ctl grammar composition explain` with `--sample-context`, `--sample-deps`, `--sample-step`, `--mock-outputs` flags (inline JSON or `@path/to/file.json`)
- **Expression reference extraction** via `extract_references()` on `ExpressionEngine` using regex-based envelope path detection

## Test plan

- [ ] 505 tasker-grammar tests pass (10 new: 5 static analysis + 5 simulation)
- [ ] 242 tasker-sdk tests pass (3 new: static, simulation, parse error)
- [ ] MCP Tier 1 tool count updated (13→14), protocol test assertions updated
- [ ] Zero clippy warnings across workspace
- [ ] `cargo check --all-features --workspace` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)